### PR TITLE
chore: add minimal repo contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - chore/**
+
+permissions:
+  contents: read
+
+jobs:
+  repo-contract:
+    name: Repository contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate repository contract
+        run: python scripts/validate_repo_contract.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# OS / editor noise
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+.vscode/
+.idea/
+
+# Logs and runtime output
+*.log
+logs/
+tmp/
+temp/
+.cache/
+
+# Environment and secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Node / Python local artifacts
+node_modules/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+
+# Build / coverage artifacts
+dist/
+build/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,82 +1,113 @@
-# awesome-firebase-use-cases
+# Cloud-360
 
-> Firebase 模板 × AI 加速器 — 用詳細文件，讓你在自己的 Firebase 環境快速落地。
+Cloud-360 是面向雲端架構師、SRE、FinOps 與 Security 團隊的 **AI-native multi-cloud architecture and operations platform**。
 
----
+平台支援 AWS、GCP、Azure 三大公有雲，透過 AI Chat、Agentic AI、MCP、Cloud SDK、Cloud CLI、Terraform / OpenTofu 與可重用 Skills，協助團隊完成架構設計、跨雲選型、成本估算、IaC 產製、安全策略檢視與日常維運最佳化。
 
-## 🎯 這個專案在做什麼？
+## Platform Vision
 
-你是不是曾經看過 Firebase 的功能，卻不知道從哪裡開始？或是架好 Firebase 之後，不知道怎麼接 AI、怎麼做自動化？
+Cloud-360 的目標是提供一個 Web-first 的多雲管理與設計工作台：
 
-**awesome-firebase-use-cases** 收集並實作了大量 Firebase 模板，每個模板都有：
+- 將自然語言需求轉成多雲架構方案。
+- 使用線上 draw.io / diagrams.net 相容畫布，讓使用者與 AI chatbot 共同編輯架構圖。
+- 比較 AWS / GCP / Azure 元件、SLA、限制、相容性與成本。
+- 估算多雲 TCO、Data Egress、Spot / Preemptible / Reserved pricing 策略。
+- 將確認後的架構轉成 Terraform / OpenTofu 模組草稿。
+- 透過 Agentic AI 主動檢查成本、安全、效能、可用性與維運風險。
+- 透過 MCP / SDK / CLI / Skills 安全地整合雲平台管理能力。
 
-- ✅ **詳細使用者手冊**（Step-by-step 文件）
-- ✅ **完整程式碼範例**（可直接複製使用）
-- ✅ **AI 整合指南**（Gemini / Vertex AI / n8n）
-- ✅ **快速上手腳本**（自己的 Firebase 專案直接啟動）
+## Core Modules
 
----
+1. **Architecture Design**
+   - 自然語言轉架構藍圖。
+   - 產生 Mermaid / PlantUML / draw.io 圖面。
+   - 檢查 Well-Architected Framework 與 HA / DR / Scalability 需求。
 
-## 📂 專案結構
+2. **Cross-Cloud Component Selection**
+   - 比較 AWS、GCP、Azure 同質服務。
+   - 依 workload profile 推薦合適雲端元件。
+   - 輸出 SLA、限制、相容性、lock-in、維運成本與替代方案。
 
-```
-awesome-firebase-use-cases/
-├── firebase_templates/          # Firebase 應用模板
-│   ├── life/                   # 生活應用
-│   ├── work/                   # 工作應用
-│   ├── dev/                    # 開發者 SDLC
-│   ├── ai/                     # Firebase × AI 整合
-│   └── social/                 # 社群/內容創作
-│
-├── workflows/                  # 自動化 Workflows
-│   └── n8n/                    # Firebase × n8n
-│
-└── tools/                      # 開發者工具
-    ├── skills/                 # OpenClaw Skills
-    └── mcp/                    # MCP Servers
-```
+3. **Cost Estimation & FinOps**
+   - 估算 Compute、Database、Storage、Network、CDN、Data Egress 與 Observability 成本。
+   - 比較 AWS Spot、Azure Spot、GCP Spot / Preemptible 等計費模式。
+   - 產出成本異常與 right-sizing 建議。
 
----
+4. **Infrastructure as Code - Terraform / OpenTofu**
+   - 產生 `aws`、`google`、`azurerm` provider 對應的 Terraform / OpenTofu 模組。
+   - 支援 `main.tf`、`variables.tf`、`outputs.tf`、`providers.tf` 與 `modules/` 結構。
+   - 整合 tfsec、trivy、Checkov 等靜態掃描工具。
 
-## 🚀 快速開始
+5. **Operations Optimization Review**
+   - 分析已部署或設計中的架構。
+   - 提供效能、可用性、成本、SLO/SLA 與架構現代化建議。
+   - 主動建議 managed service、serverless、container platform 或跨雲遷移方案。
+
+6. **AI Multi-Cloud Operations**
+   - 使用 AI Chat 主動查詢、分析與管理 AWS / GCP / Azure。
+   - 透過 Agentic AI 被動監控、主動分析與產生維運建議。
+   - 透過 MCP servers、Cloud SDKs、Cloud CLIs 與 Skills 執行受控操作。
+
+7. **Cloud Security Posture & Policy Advisory**
+   - 檢視 IAM / RBAC、network exposure、storage access、encryption、audit logging、policy guardrails。
+   - 產生 least-privilege、Policy-as-Code、IaC patch 與 remediation plan 建議。
+   - 高風險修復必須通過 human approval gate。
+
+## Web-Based Desktop and Mobile Experience
+
+Cloud-360 是 Web-first 平台，第一階段不做 native iOS / Android app。
+
+- **Desktop Web**：完整工作台，包含 draw.io co-editing、IaC editor、FinOps dashboard、Security dashboard、Ops dashboard、Agent trace 與 audit log。
+- **Mobile Web / Responsive Web / PWA**：維運伴隨介面，聚焦 AI Chat、alerts、approval workflow、cloud health digest、security / cost findings 與 readonly architecture diagram review。
+
+## Architecture Visualization Canvas
+
+Cloud-360 採用線上 **draw.io / diagrams.net-compatible architecture canvas**。使用者可以手動編輯架構圖，也可以透過 AI Chat 以自然語言要求 AI 共同修改圖面。
+
+圖面不只是圖片，而是系統的 shared architecture context：
+
+- source format：`.drawio` / diagrams.net XML
+- derived format：Mermaid、PlantUML、SVG、PNG、internal architecture graph JSON
+- downstream consumers：Design Agent、FinOps Agent、IaC Agent、Ops Agent、Security Policy Advisor Agent
+
+## Cloud Operation Integration
+
+Cloud-360 透過以下方式整合雲平台：
+
+- MCP servers
+- Cloud SDKs
+- Cloud CLIs
+- Terraform / OpenTofu providers
+- AI Skills
+- Cloud-native monitoring, billing, IAM, policy and security APIs
+
+Read-only 查詢與分析可直接執行；write / delete / deploy / permission change / production-impacting action 必須先產生 plan、impact、rollback strategy，並通過 human approval gate。
+
+## Documentation
+
+- [System Requirement Specification](docs/srs/cloud-360-srs.md)
+- [System Architecture](docs/architecture/system-architecture.md)
+- [Core Pillars User Stories](docs/user-stories/core-pillars.md)
+- [ADR 0001: Repository Scope](docs/adr/0001-repo-scope.md)
+- [ADR 0002: Agent Routing Layer](docs/adr/0002-agent-routing-layer.md)
+- [ADR 0003: Web-Based Desktop and Mobile Experience](docs/adr/0003-web-based-experience.md)
+
+## Repository Contract
+
+This repository currently tracks the Cloud-360 SDD baseline:
+
+- platform SRS
+- architecture diagrams
+- user stories
+- ADRs
+- repository validation script
+- baseline CI
+
+Production credentials, environment-specific secrets, direct production IaC, and destructive cloud operations are explicitly out of scope unless reviewed and approved through future ADRs.
+
+## Validation
 
 ```bash
-# 1. 挑選你想要的 Template
-# 2. 詳見各資料夾的 README.md
-# 3. 跟著文件一步步建立自己的 Firebase 專案
+python scripts/validate_repo_contract.py
+git diff --check
 ```
-
----
-
-## 📚 文件目標
-
-這個專案的核心特色是**文件品質**。
-
-每個 Template 的 README.md 都包含：
-
-| 區塊 | 內容 |
-|------|------|
-| 場景介紹 | 這個 Template 解決什麼問題 |
-| 前置需求 | 需要哪些 Firebase 服務與 API Key |
-| 安裝步驟 | 在自己的 Firebase 專案中如何設定 |
-| 功能說明 | 各功能的操作方式 |
-| AI 整合 | 怎麼接 Gemini / Vertex AI |
-| 客製化指南 | 怎麼改成自己的品牌 |
-| 部署方式 | Firebase Hosting / Cloud Run 部署 |
-
----
-
-## 🤝 貢獻方式
-
-歡迎提交 Issue 回報問題，或 Pull Request 貢獻新的 Template！
-
-1. Fork 此專案
-2. 建立新資料夾（格式：`firebase_templates/[分類]/[template-name]`）
-3. 包含完整 README.md（依上方文件模板）
-4. Pull Request → 我們會 Review 文件與程式碼
-
----
-
-## 📄 License
-
-MIT License

--- a/docs/adr/0001-repo-scope.md
+++ b/docs/adr/0001-repo-scope.md
@@ -1,0 +1,43 @@
+# ADR 0001: Repository Scope
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+This repository is being initialized with a minimal repository contract so future changes have a stable baseline for structure, validation, and CI.
+
+The current top-level README is known to be inaccurate and is intentionally excluded from this contract. This ADR defines the minimal scope without relying on README content.
+
+## Decision
+
+The repository contract is limited to:
+
+1. Ignore local-only, generated, secret, and build artifacts via `.gitignore`.
+2. Keep repository-level architectural decisions under `docs/adr/`.
+3. Validate the contract with `scripts/validate_repo_contract.py`.
+4. Run the validation script in GitHub Actions on pull requests and pushes.
+
+This contract does not introduce production configuration, deployment targets, infrastructure credentials, runtime secrets, or environment-specific settings.
+
+## Scope
+
+In scope:
+
+- Documentation for repository-level decisions.
+- Local development hygiene such as `.gitignore`.
+- CI validation that checks repository contract files exist and avoids accidental README dependency.
+
+Out of scope:
+
+- Production deployment configuration.
+- Infrastructure-as-code for production resources.
+- Environment secrets or credentials.
+- Application runtime implementation.
+- README correction or rewrite.
+
+## Consequences
+
+- Future changes can extend the contract through additional ADRs and validation checks.
+- CI provides an early guardrail without assuming application language, package manager, or deployment platform.
+- README remediation remains a separate task and must not block this minimal contract.

--- a/docs/adr/0001-repo-scope.md
+++ b/docs/adr/0001-repo-scope.md
@@ -1,43 +1,66 @@
-# ADR 0001: Repository Scope
+# ADR 0001: Cloud-360 Repository Scope
 
 - Status: Accepted
 - Date: 2026-05-02
 
 ## Context
 
-This repository is being initialized with a minimal repository contract so future changes have a stable baseline for structure, validation, and CI.
+Cloud-360 is being defined through Spec-Driven Development before application implementation begins. The repository needs a clear contract so future changes can extend the platform safely without introducing production configuration, secrets, or uncontrolled cloud operations.
 
-The current top-level README is known to be inaccurate and is intentionally excluded from this contract. This ADR defines the minimal scope without relying on README content.
+The platform vision is an AI-native multi-cloud architecture, governance, security and operations platform for Cloud Architects, SRE, FinOps and Security teams.
 
 ## Decision
 
-The repository contract is limited to:
+This repository tracks the Cloud-360 SDD baseline:
 
-1. Ignore local-only, generated, secret, and build artifacts via `.gitignore`.
-2. Keep repository-level architectural decisions under `docs/adr/`.
-3. Validate the contract with `scripts/validate_repo_contract.py`.
-4. Run the validation script in GitHub Actions on pull requests and pushes.
+1. Product README.
+2. System Requirement Specification under `docs/srs/`.
+3. System architecture documents under `docs/architecture/`.
+4. User stories under `docs/user-stories/`.
+5. Architecture Decision Records under `docs/adr/`.
+6. Repository validation script under `scripts/`.
+7. Baseline GitHub Actions CI under `.github/workflows/`.
 
-This contract does not introduce production configuration, deployment targets, infrastructure credentials, runtime secrets, or environment-specific settings.
+Cloud-360 scope includes:
 
-## Scope
+- AWS / GCP / Azure multi-cloud architecture design.
+- Cross-cloud component selection.
+- FinOps and cost estimation.
+- Terraform / OpenTofu IaC generation.
+- Operations optimization.
+- AI Chat driven cloud management.
+- Agentic AI proactive operations analysis.
+- Cloud Security Posture & Policy Advisory.
+- draw.io / diagrams.net compatible architecture canvas.
+- Web-based desktop and mobile experience.
 
-In scope:
+## Guardrails
 
-- Documentation for repository-level decisions.
-- Local development hygiene such as `.gitignore`.
-- CI validation that checks repository contract files exist and avoids accidental README dependency.
+The repository must not introduce the following without a future explicit ADR and approval:
 
-Out of scope:
+- Plaintext cloud credentials or secrets.
+- Production-specific deployment configuration.
+- Direct production Terraform state or backend configuration.
+- Autonomous destructive cloud actions.
+- Unreviewed IAM/RBAC, firewall, KMS, storage policy or production-impacting changes.
 
-- Production deployment configuration.
-- Infrastructure-as-code for production resources.
-- Environment secrets or credentials.
-- Application runtime implementation.
-- README correction or rewrite.
+All write/delete/deploy/permission-changing cloud operations must include:
+
+- plan
+- impact analysis
+- affected resources
+- rollback strategy
+- verification steps
+- human approval gate
+- audit log
+
+## Branch Collaboration Constraint
+
+`feature/cloud_architecture` is a collaborative branch and must remain read-only unless Danniel explicitly authorizes modifications. Do not clean, rebase, force-push, delete, or rewrite that branch.
 
 ## Consequences
 
-- Future changes can extend the contract through additional ADRs and validation checks.
-- CI provides an early guardrail without assuming application language, package manager, or deployment platform.
-- README remediation remains a separate task and must not block this minimal contract.
+- README is now allowed to represent Cloud-360 product direction.
+- SDD documents become the source of truth for initial implementation.
+- CI validates that required contract documents exist and contain key platform concepts.
+- Future implementation work should extend this contract through new ADRs and tests.

--- a/docs/adr/0002-agent-routing-layer.md
+++ b/docs/adr/0002-agent-routing-layer.md
@@ -1,0 +1,61 @@
+# ADR 0002: Agent Routing Layer
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+Cloud-360 must coordinate multiple AI capabilities: architecture design, cross-cloud service selection, FinOps, Terraform generation, operations review, security policy advisory and cloud tool execution.
+
+A single monolithic agent would make routing, permission checks, auditability and context reuse difficult. Cloud-360 therefore needs an explicit Agent Routing Layer.
+
+## Decision
+
+Cloud-360 will use an OpenClaw-like multi-agent routing layer.
+
+Initial agent roles:
+
+- **Routing Agent**：classifies intent and orchestrates task flow。
+- **Intent Parser Agent**：extracts requirements, assumptions and missing inputs。
+- **Design Agent**：creates architecture candidates and diagrams。
+- **Component Selection Agent**：maps workloads to AWS/GCP/Azure services。
+- **FinOps Agent**：estimates cost and compares pricing strategies。
+- **IaC Agent**：generates Terraform / OpenTofu modules。
+- **Operations Agent**：reviews performance, reliability and modernization opportunities。
+- **Security Policy Advisor Agent**：reviews security posture and recommends policies。
+- **Tool Execution Agent**：executes approved MCP / SDK / CLI / Skill calls。
+- **Guardrail Agent**：enforces permission, approval and safety policies。
+
+## Shared Context
+
+Agents must share structured context through memory and artifact stores:
+
+- user requirement
+- assumptions
+- architecture graph
+- draw.io XML
+- cost model
+- selected cloud components
+- generated IaC
+- security findings
+- approval decisions
+- audit records
+
+## Safety Model
+
+Read-only queries may execute after policy classification. High-risk actions require human approval:
+
+- write / delete / deploy
+- IAM/RBAC or permission changes
+- firewall / security group / NSG changes
+- KMS / key policy changes
+- storage access changes
+- production Terraform apply
+- scaling changes with cost or availability impact
+
+## Consequences
+
+- Agents can be developed and tested independently.
+- Tool execution is isolated behind policy and approval gates.
+- All recommendations can be traced to source context and tool output.
+- Future agents can be added through ADRs without changing the core platform contract.

--- a/docs/adr/0003-web-based-experience.md
+++ b/docs/adr/0003-web-based-experience.md
@@ -1,0 +1,72 @@
+# ADR 0003: Web-Based Desktop and Mobile Experience
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+Cloud-360 must support both desktop usage and mobile usage, but the first phase should avoid native iOS and Android development complexity.
+
+The platform also includes draw.io / diagrams.net editing, dashboards, AI Chat, approval workflows and audit trails. These capabilities can share one Web application architecture with responsive layouts.
+
+## Decision
+
+Cloud-360 will be delivered as a Web-first platform.
+
+Supported first-phase UI surfaces:
+
+- Desktop Web
+- Tablet Web
+- Mobile Web
+- Responsive Web
+- Optional PWA features
+
+Out of initial scope:
+
+- Native iOS app
+- Native Android app
+
+## Desktop Web Responsibilities
+
+Desktop Web provides the full workspace:
+
+- AI Chat
+- draw.io / diagrams.net co-editing
+- Terraform / policy code editor
+- FinOps dashboard
+- Security posture dashboard
+- Operations dashboard
+- Agent workflow trace
+- Audit log
+- Approval gate management
+
+## Mobile Web Responsibilities
+
+Mobile Web is an ops companion:
+
+- AI Chat
+- Alerts
+- Approval / rejection workflow
+- Cloud health digest
+- Cost / security / operations findings
+- Readonly architecture diagram review
+- Incident quick triage
+
+Mobile Web is not the primary interface for large-scale architecture diagram editing or deep Terraform development.
+
+## Security Requirements
+
+High-risk mobile approvals must support strong confirmation, such as:
+
+- MFA
+- passkey
+- WebAuthn
+- session re-authentication
+
+All approvals and rejections must be written to audit log.
+
+## Consequences
+
+- The platform can share backend, API, authentication, RBAC, audit log and agent context across desktop and mobile web.
+- UI implementation must prioritize responsive layout and mobile-readable summaries.
+- Native app work can be reconsidered later through a separate ADR.

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -1,0 +1,149 @@
+# Cloud-360 System Architecture
+
+## High-Level Architecture
+
+```mermaid
+flowchart TB
+    User[Cloud Architect / SRE / FinOps / Security] --> Browser[Web Browser]
+
+    Browser --> Desktop[Desktop Web Experience<br/>Full Workspace]
+    Browser --> Mobile[Mobile Web / Responsive Web / PWA<br/>Ops Companion]
+
+    Desktop --> Chat[AI Chat]
+    Desktop --> DrawIO[draw.io / diagrams.net Canvas<br/>AI Co-editing]
+    Desktop --> IaCEditor[Terraform / Policy Editor]
+    Desktop --> FinOpsUI[FinOps Dashboard]
+    Desktop --> SecUI[Security Posture Dashboard]
+    Desktop --> OpsUI[Operations Dashboard]
+
+    Mobile --> MobileChat[Mobile Web AI Chat]
+    Mobile --> Alerts[Alerts / Findings]
+    Mobile --> ApprovalUI[Approval Workflow]
+    Mobile --> Digest[Cloud Health Digest]
+    Mobile --> DiagramRO[Readonly Diagram View]
+
+    Chat --> APIGW[API Gateway]
+    DrawIO --> APIGW
+    IaCEditor --> APIGW
+    FinOpsUI --> APIGW
+    SecUI --> APIGW
+    OpsUI --> APIGW
+    MobileChat --> APIGW
+    Alerts --> APIGW
+    ApprovalUI --> APIGW
+    Digest --> APIGW
+    DiagramRO --> APIGW
+
+    APIGW --> Auth[Auth / RBAC / MFA / WebAuthn]
+    Auth --> Backend[Backend Service<br/>Python or Java]
+
+    Backend --> Router[Agent Routing Layer<br/>OpenClaw-like Multi-Agent Framework]
+    Backend --> Memory[(Shared Context / Memory)]
+    Backend --> ArtifactStore[(Artifact Store<br/>draw.io / IaC / Reports)]
+    Backend --> Audit[(Audit Log)]
+    Backend --> Policy[Policy / Permission Engine]
+    Backend --> Approval[Human Approval Gate]
+
+    Router --> Intent[Intent Parser Agent]
+    Router --> Design[Design Agent]
+    Router --> Selector[Component Selection Agent]
+    Router --> FinOps[FinOps Agent]
+    Router --> IaC[IaC Agent]
+    Router --> Ops[Operations Agent]
+    Router --> Security[Security Policy Advisor Agent]
+    Router --> ToolExec[Tool Execution Agent]
+    Router --> Guardrail[Guardrail Agent]
+
+    DrawIO --> DiagramAdapter[draw.io XML Adapter]
+    DiagramAdapter --> ArchGraph[Internal Architecture Graph]
+    ArchGraph --> Memory
+    ArchGraph --> Design
+    ArchGraph --> FinOps
+    ArchGraph --> IaC
+    ArchGraph --> Ops
+    ArchGraph --> Security
+
+    ToolExec --> Integration[Cloud Operation Integration Layer]
+
+    Integration --> MCP[MCP Servers]
+    Integration --> Skills[AI Skills]
+    Integration --> SDK[Cloud SDKs]
+    Integration --> CLI[Cloud CLIs]
+    Integration --> IaCTools[Terraform / OpenTofu / tfsec / trivy / Checkov]
+
+    Integration --> AWS[AWS APIs]
+    Integration --> GCP[GCP APIs]
+    Integration --> Azure[Azure APIs]
+
+    AWS --> AWSSignals[CloudWatch / Config / Cost Explorer / IAM Access Analyzer / Security Hub / GuardDuty]
+    GCP --> GCPSignals[Cloud Monitoring / Logging / Asset Inventory / Billing / SCC / Org Policy]
+    Azure --> AzureSignals[Azure Monitor / Log Analytics / Cost Management / Policy / Defender]
+
+    AWSSignals --> Agentic[Agentic AI Operations]
+    GCPSignals --> Agentic
+    AzureSignals --> Agentic
+
+    Agentic --> Router
+    Agentic --> Alerts
+    Agentic --> Digest
+```
+
+## Architecture Principles
+
+1. **Web-first**：桌面與手機都以 Web 呈現，Mobile 使用 responsive web / PWA。
+2. **AI as co-operator**：AI Chat 不只回答問題，也可共同編輯 draw.io 架構圖、產生 Terraform、分析成本與安全風險。
+3. **Agentic AI with guardrails**：Agent 可主動分析與建議，但高風險操作需 human approval。
+4. **Diagram as structured context**：draw.io 圖面需轉為 internal architecture graph，供 agents 使用。
+5. **Cloud operations through controlled integration layer**：所有 AWS/GCP/Azure 操作經 MCP / SDK / CLI / Skills abstraction。
+6. **No secret leakage**：secrets 不得進入 Git、log、prompt、artifact 或 final report。
+
+## Agent Routing Example
+
+User request:
+
+```text
+我要一個可乘載 1 萬人同時在線的電商後端，請幫我評估部署在 AWS 與 Azure 上的成本差異，並產出較便宜方案的 Terraform 腳本。
+```
+
+```mermaid
+flowchart TD
+    U[User Input] --> R[Routing Agent]
+    R --> P[Intent Parser Agent]
+    P --> Ctx[Create / Update Shared Context]
+    P --> Req[Requirement Extraction]
+    Req --> ReqCheck{需求是否足夠?}
+
+    ReqCheck -- 不足 --> Q[Clarification or Assumption Builder]
+    Q --> Ctx
+
+    ReqCheck -- 足夠 --> Design[Design Agent]
+    Ctx --> Design
+    Design --> Diagram[Architecture Candidate + draw.io / Mermaid]
+    Diagram --> Selector[Component Selection Agent]
+
+    Selector --> AWSPlan[AWS Component Plan]
+    Selector --> AzurePlan[Azure Component Plan]
+
+    AWSPlan --> FinOps[FinOps Agent]
+    AzurePlan --> FinOps
+    FinOps --> Compare[AWS vs Azure Monthly TCO]
+
+    Compare --> Decision{Cheaper and acceptable risk?}
+    Decision -- AWS --> AWSSelected[AWS Selected]
+    Decision -- Azure --> AzureSelected[Azure Selected]
+    Decision -- Risky --> HumanReview[Human Review Required]
+
+    AWSSelected --> IaC[IaC Agent]
+    AzureSelected --> IaC
+    IaC --> TF[Generate Terraform / OpenTofu Modules]
+    TF --> Scan[tfsec / trivy / Checkov]
+    Scan --> Pass{Scan Passed?}
+    Pass -- No --> Remediate[Remediation Loop]
+    Remediate --> TF
+    Pass -- Yes --> Report[Final Report]
+
+    Compare --> Report
+    Diagram --> Report
+    TF --> Report
+    Scan --> Report
+```

--- a/docs/srs/cloud-360-srs.md
+++ b/docs/srs/cloud-360-srs.md
@@ -1,0 +1,184 @@
+# Cloud-360 System Requirement Specification
+
+- Status: Draft v0.1
+- Date: 2026-05-02
+- Owner: Danniel Chung / Anita
+
+## 1. Platform Vision
+
+Cloud-360 是專為雲端架構師、SRE、FinOps 與 Security 團隊設計的 AI-native 多雲架構與維運管理平台。
+
+平台深度整合 LLM、多智能體協作框架、MCP servers、Cloud SDKs、Cloud CLIs、Terraform / OpenTofu 與可重用 Skills，提供涵蓋 AWS、GCP、Azure 的端到端生命週期管理能力。
+
+## 2. Target Users
+
+- Cloud Architect
+- SRE / Platform Engineer
+- FinOps Analyst
+- Security Reviewer
+- Engineering Manager / Technical Decision Maker
+
+## 3. Core Pillars
+
+### A. AI-Driven Architecture Design
+
+Cloud-360 將自然語言需求轉成單雲或多雲架構藍圖。
+
+Required capabilities:
+
+- 解析 workload、HA、DR、RTO/RPO、scalability、security、compliance、latency 與 region 需求。
+- 產生 Mermaid / PlantUML / draw.io 架構圖。
+- 檢查 AWS / GCP / Azure Well-Architected Framework。
+- 支援 Active-Active / Active-Passive cross-cloud disaster recovery design。
+
+### B. Cross-Cloud Component Selection
+
+Cloud-360 根據 workload profile 提供 AWS / GCP / Azure 託管服務選型建議。
+
+Required capabilities:
+
+- 比較同質服務，例如 AWS RDS、GCP Cloud SQL、Azure SQL Database。
+- 輸出效能、SLA、限制、相容性、lock-in、維運複雜度與成本風險。
+- 產生 decision matrix 與替代方案。
+
+### C. Cost Estimation & FinOps
+
+Cloud-360 針對架構方案與雲端元件估算多雲 TCO。
+
+Required capabilities:
+
+- 根據流量、運算資源、資料量、儲存、備援、observability 與 data transfer 估算月費。
+- 比較 AWS Spot、Azure Spot Virtual Machines、GCP Spot / Preemptible VMs。
+- 計算跨雲與跨區 Data Egress。
+- 主動偵測 cost spike、idle resources、over-provisioned resources 與 right-sizing opportunity。
+
+### D. Infrastructure as Code - Terraform / OpenTofu
+
+Cloud-360 將確認後的架構藍圖轉為 Terraform / OpenTofu 模組草稿。
+
+Required capabilities:
+
+- 支援 `aws`、`google`、`azurerm` providers。
+- 產出 `providers.tf`、`main.tf`、`variables.tf`、`outputs.tf` 與 `modules/` 結構。
+- 不產生 production secrets。
+- 所有 sensitive values 必須使用 variables、secret manager reference 或 workload identity。
+- 整合 tfsec、trivy、Checkov 進行靜態掃描。
+
+### E. Operations Optimization Review
+
+Cloud-360 針對已部署或設計中的架構進行持續健康檢查與效能檢視。
+
+Required capabilities:
+
+- 分析 CPU、memory、IOPS、network、storage、latency、error rate、SLO/SLA。
+- 提供 right-sizing、autoscaling、backup、multi-AZ、multi-region 與 observability 建議。
+- 根據雲端新服務提出架構現代化建議。
+
+### F. AI Multi-Cloud Operations
+
+Cloud-360 透過 AI Chat 與 Agentic AI 管理多雲環境。
+
+Required capabilities:
+
+- AI Chat 主動式操作：使用者以自然語言查詢、分析與要求維運操作。
+- Agentic AI 被動監控與主動分析：背景 agent 監控成本、安全、效能、可用性與政策風險。
+- 串接 AWS / GCP / Azure MCP、SDK、CLI、API、Skills 與 Terraform providers。
+- 所有高風險操作必須有人類審批。
+- 所有操作必須記錄 audit log。
+
+### G. Cloud Security Posture & Policy Advisory
+
+Cloud-360 檢視多雲安全策略並提出可執行的治理建議。
+
+Required capabilities:
+
+- 檢查 IAM / RBAC、Security Group / Firewall / NSG、bucket / blob access、KMS / encryption、audit logging、cloud-native policy guardrails。
+- 整合 AWS IAM Access Analyzer、AWS Config、Security Hub、GuardDuty、GCP Security Command Center、GCP Organization Policy、Azure Policy、Defender for Cloud、Azure Advisor 等資料來源。
+- 針對 findings 產生 severity、evidence、impact、recommended policy、remediation plan、IaC patch suggestion、verification command、rollback strategy。
+- 支援 Policy-as-Code 建議，例如 OPA/Rego、Sentinel、Azure Policy、GCP Org Policy、AWS Config rule。
+
+## 4. User Experience Requirements
+
+### Desktop Web
+
+Desktop Web 是 Cloud-360 的完整工作台，必須支援：
+
+- AI Chat
+- draw.io / diagrams.net architecture canvas
+- Terraform / policy code editor
+- FinOps dashboard
+- Security posture dashboard
+- Operations dashboard
+- Agent trace
+- Audit log
+- Approval gate management
+
+### Mobile Web / Responsive Web / PWA
+
+手機版本也以 Web 方式呈現。第一階段不做 native iOS / Android app。
+
+Mobile Web 聚焦：
+
+- AI Chat
+- Alerts
+- Approval / reject workflow
+- Cloud health digest
+- Cost / security / operations findings
+- Readonly architecture diagram view
+- Incident quick triage
+
+Mobile Web 不作為大型 draw.io 圖面拖拉編輯或 Terraform 深度開發的主要介面。
+
+## 5. Architecture Visualization Requirements
+
+Cloud-360 的架構圖能力以 draw.io / diagrams.net 相容格式為核心。
+
+Required capabilities:
+
+- 支援 `.drawio` / XML source format。
+- 支援 SVG / PNG / PDF export。
+- 支援 Mermaid / PlantUML derived output。
+- AI Chat 可新增元件、刪除元件、調整連線、標註資料流、補 HA/DR/security/observability 元件。
+- 每次 AI 修改需產生 change summary 與 version history。
+- 圖面需可解析成 internal architecture graph，供 FinOps、IaC、Ops、Security agents 使用。
+
+## 6. Cloud Integration Requirements
+
+Cloud-360 必須透過受控 integration layer 串接雲平台。
+
+Integration types:
+
+- MCP servers
+- Cloud SDKs
+- Cloud CLIs
+- Cloud APIs
+- Terraform / OpenTofu providers
+- AI Skills
+
+Safety requirements:
+
+- Read-only operations may execute after policy classification。
+- Write / delete / deploy / permission change / production-impacting operations require human approval。
+- Before execution, system must provide plan, impact, rollback strategy, affected resources and verification steps。
+- Secrets must never be logged, committed, or returned to users。
+
+## 7. Non-Functional Requirements
+
+- Security by default
+- Auditability
+- RBAC and least privilege
+- Human approval gate for high-risk actions
+- Multi-cloud extensibility
+- Explainable AI decisions
+- Reproducible IaC generation
+- Clear separation between recommendation and execution
+- Responsive Web support for desktop, tablet and mobile browsers
+
+## 8. Initial Out of Scope
+
+- Native iOS application
+- Native Android application
+- Direct production deployment without approval workflow
+- Storing plaintext cloud credentials
+- Autonomous destructive cloud changes
+- Treating third-party collaborative branches as editable without explicit authorization

--- a/docs/user-stories/core-pillars.md
+++ b/docs/user-stories/core-pillars.md
@@ -1,0 +1,219 @@
+# Cloud-360 Core Pillars User Stories
+
+## A. Architecture Design
+
+### A1. Natural Language to Architecture
+
+As a Cloud Architect, I want to describe requirements in natural language so that Cloud-360 can generate an initial cloud architecture blueprint.
+
+Acceptance criteria:
+
+- Extracts workload, HA, DR, scalability, region, security and compliance requirements.
+- Produces Mermaid, PlantUML or draw.io output.
+- Explains assumptions and trade-offs.
+
+### A2. Well-Architected Review
+
+As an SRE, I want Cloud-360 to check whether an architecture follows cloud provider best practices.
+
+Acceptance criteria:
+
+- Covers reliability, security, cost optimization, operational excellence and performance.
+- Produces severity, impact and remediation recommendations.
+
+### A3. AI + draw.io Co-editing
+
+As a Cloud Architect, I want AI Chat to co-edit an online draw.io / diagrams.net architecture canvas.
+
+Acceptance criteria:
+
+- Supports `.drawio` / XML source format.
+- AI can add/remove nodes, update connections and annotate data flow.
+- Every AI modification includes a change summary and version history.
+- Diagram structure can be parsed into shared architecture context.
+
+## B. Cross-Cloud Component Selection
+
+### B1. Service Comparison Matrix
+
+As a technical decision maker, I want to compare equivalent AWS/GCP/Azure services.
+
+Acceptance criteria:
+
+- Includes SLA, limits, compatibility, cost risk, lock-in risk and operational complexity.
+- Supports compute, database, storage, network, Kubernetes, messaging and AI/ML categories.
+
+### B2. Workload-Based Recommendation
+
+As an SRE, I want Cloud-360 to recommend cloud services based on workload profile.
+
+Acceptance criteria:
+
+- Uses QPS, concurrency, data size, latency target, region and compliance constraints.
+- Provides rationale, alternatives and known limitations.
+
+## C. Cost Estimation & FinOps
+
+### C1. Monthly TCO Estimation
+
+As a FinOps analyst, I want monthly cost estimation for a proposed architecture.
+
+Acceptance criteria:
+
+- Estimates compute, database, cache, storage, network, CDN, egress and observability.
+- Shows pricing assumptions and source timestamp.
+
+### C2. Spot / Preemptible Comparison
+
+As an SRE, I want to compare on-demand and interruptible pricing options.
+
+Acceptance criteria:
+
+- Covers AWS Spot, Azure Spot and GCP Spot / Preemptible.
+- Includes savings estimate and interruption risk.
+
+### C3. Cross-Cloud Egress Analysis
+
+As an architect, I want to understand data egress cost in multi-cloud designs.
+
+Acceptance criteria:
+
+- Distinguishes intra-region, inter-region, internet egress and cross-cloud traffic.
+- Flags expensive or risky traffic paths.
+
+## D. Terraform / OpenTofu IaC Generation
+
+### D1. Modular IaC Generation
+
+As a platform engineer, I want Cloud-360 to generate modular Terraform / OpenTofu code.
+
+Acceptance criteria:
+
+- Generates `providers.tf`, `main.tf`, `variables.tf`, `outputs.tf` and `modules/`.
+- Supports `aws`, `google` and `azurerm` providers.
+- Does not generate plaintext secrets.
+
+### D2. IaC Security Scan
+
+As a security reviewer, I want generated IaC to be scanned before use.
+
+Acceptance criteria:
+
+- Supports tfsec, trivy or Checkov.
+- Flags public storage, overly broad ingress, missing encryption and excessive IAM/RBAC.
+- Produces remediation guidance.
+
+## E. Operations Optimization Review
+
+### E1. Right-sizing Recommendation
+
+As an SRE, I want right-sizing recommendations based on observed utilization.
+
+Acceptance criteria:
+
+- Analyzes CPU, memory, IOPS, network and storage.
+- Estimates cost impact after changes.
+- Requires approval before changing production resources.
+
+### E2. Architecture Modernization
+
+As a Cloud Architect, I want modernization recommendations based on new cloud services.
+
+Acceptance criteria:
+
+- Identifies legacy, high-maintenance or high-cost services.
+- Suggests managed, serverless, container or event-driven alternatives.
+- Includes migration risk and expected benefits.
+
+## F. AI Multi-Cloud Operations
+
+### F1. AI Chat Cloud Query
+
+As an SRE, I want to query AWS/GCP/Azure status through AI Chat.
+
+Acceptance criteria:
+
+- Supports account/project/subscription and region selection.
+- Can query resource inventory, cost, metrics, logs and IAM/security findings.
+- Includes data source and query time.
+- Redacts secrets.
+
+### F2. AI Chat Cloud Operation
+
+As a platform engineer, I want to request cloud operations through AI Chat.
+
+Acceptance criteria:
+
+- Read-only actions can execute after policy classification.
+- Write/delete/deploy/permission changes require human approval.
+- Shows plan, impact, rollback and verification steps.
+- Records audit log.
+
+### F3. Agentic AI Operations
+
+As an operations lead, I want background agents to proactively identify issues.
+
+Acceptance criteria:
+
+- Detects cost spikes, security risks, availability gaps and performance bottlenecks.
+- Produces recommendations and remediation plans.
+- Does not execute high-risk changes without explicit approval.
+
+## G. Cloud Security Posture & Policy Advisory
+
+### G1. Multi-Cloud Security Review
+
+As a Security Reviewer, I want Cloud-360 to inspect security posture across AWS/GCP/Azure.
+
+Acceptance criteria:
+
+- Checks IAM/RBAC, network exposure, storage access, encryption, audit logging and policy guardrails.
+- Produces severity, evidence, impact and remediation.
+
+### G2. Least-Privilege Analysis
+
+As a platform admin, I want Cloud-360 to detect over-permissive identities.
+
+Acceptance criteria:
+
+- Detects wildcard permissions, stale identities and unused permissions.
+- Generates least-privilege recommendations.
+
+### G3. Policy-as-Code Recommendation
+
+As a platform engineer, I want security policies expressed as maintainable policy code.
+
+Acceptance criteria:
+
+- Supports Terraform patch suggestions, OPA/Rego, Sentinel, Azure Policy, GCP Org Policy and AWS Config rule recommendations.
+- Requires approval before applying policy changes.
+
+## H. Web-Based Desktop and Mobile Experience
+
+### H1. Desktop Web Full Workspace
+
+As a Cloud Architect, I want the desktop browser experience to provide the full Cloud-360 workspace.
+
+Acceptance criteria:
+
+- Supports AI Chat, draw.io editor, IaC editor, FinOps dashboard, Security dashboard, Ops dashboard and agent trace.
+
+### H2. Mobile Web Ops Companion
+
+As an SRE, I want a mobile browser experience for quick operations and approvals.
+
+Acceptance criteria:
+
+- Delivered through responsive web / PWA.
+- Supports AI Chat, alerts, approvals, health digest, findings and readonly architecture diagrams.
+- Does not require native iOS or Android app.
+
+### H3. Mobile Web Approval
+
+As a platform owner, I want to approve or reject operations from mobile web safely.
+
+Acceptance criteria:
+
+- Shows plan, affected resources, risk, impact and rollback.
+- High-risk approval requires MFA, passkey or WebAuthn.
+- Records audit log and supports timeout/escalation.

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate the minimal repository contract for cloud-360.
+
+This intentionally avoids README.md because the current README is known to be
+incorrect and must not be treated as the source of truth for this contract.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_FILES = (
+    ".gitignore",
+    "docs/adr/0001-repo-scope.md",
+    "scripts/validate_repo_contract.py",
+    ".github/workflows/ci.yml",
+)
+FORBIDDEN_NEW_PATH_PARTS = {
+    "prod",
+    "production",
+    "secrets",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def git_diff_name_only(*args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", *args],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def validate_required_files() -> int:
+    missing = [path for path in REQUIRED_FILES if not (ROOT / path).is_file()]
+    if missing:
+        return fail("Missing required contract files: " + ", ".join(missing))
+    return 0
+
+
+def validate_readme_not_modified() -> int:
+    changed_files = set(git_diff_name_only("--cached")) | set(git_diff_name_only())
+    if "README.md" in changed_files:
+        return fail("README.md must not be modified by the minimal repo contract")
+    return 0
+
+
+def validate_no_production_config_added() -> int:
+    changed_files = set(git_diff_name_only("--cached")) | set(git_diff_name_only())
+    violations: list[str] = []
+
+    for path in changed_files:
+        parts = {part.lower() for part in Path(path).parts}
+        if parts & FORBIDDEN_NEW_PATH_PARTS:
+            violations.append(path)
+
+    if violations:
+        return fail(
+            "Production/secret-scoped paths are out of scope for this contract: "
+            + ", ".join(sorted(violations))
+        )
+    return 0
+
+
+def main() -> int:
+    checks = (
+        validate_required_files,
+        validate_readme_not_modified,
+        validate_no_production_config_added,
+    )
+    for check in checks:
+        result = check()
+        if result != 0:
+            return result
+
+    print("Repository contract validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the minimal repository contract for cloud-360.
-
-This intentionally avoids README.md because the current README is known to be
-incorrect and must not be treated as the source of truth for this contract.
-"""
+"""Validate the Cloud-360 repository contract."""
 
 from __future__ import annotations
 
@@ -11,19 +7,81 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
+
 REQUIRED_FILES = (
+    "README.md",
     ".gitignore",
-    "docs/adr/0001-repo-scope.md",
-    "scripts/validate_repo_contract.py",
     ".github/workflows/ci.yml",
+    "docs/srs/cloud-360-srs.md",
+    "docs/architecture/system-architecture.md",
+    "docs/user-stories/core-pillars.md",
+    "docs/adr/0001-repo-scope.md",
+    "docs/adr/0002-agent-routing-layer.md",
+    "docs/adr/0003-web-based-experience.md",
+    "scripts/validate_repo_contract.py",
 )
+
+REQUIRED_TEXT = {
+    "README.md": (
+        "Cloud-360",
+        "AWS",
+        "GCP",
+        "Azure",
+        "draw.io",
+        "Mobile Web",
+        "Cloud Security Posture",
+        "human approval gate",
+    ),
+    "docs/srs/cloud-360-srs.md": (
+        "AI Multi-Cloud Operations",
+        "Cloud Security Posture & Policy Advisory",
+        "Mobile Web",
+        "MCP servers",
+        "Terraform / OpenTofu",
+    ),
+    "docs/architecture/system-architecture.md": (
+        "Agent Routing Layer",
+        "Cloud Operation Integration Layer",
+        "draw.io",
+        "Security Policy Advisor Agent",
+    ),
+    "docs/user-stories/core-pillars.md": (
+        "Architecture Design",
+        "Cost Estimation & FinOps",
+        "Cloud Security Posture",
+        "Mobile Web",
+    ),
+    "docs/adr/0001-repo-scope.md": (
+        "Spec-Driven Development",
+        "feature/cloud_architecture",
+        "read-only",
+    ),
+    "docs/adr/0002-agent-routing-layer.md": (
+        "Routing Agent",
+        "Security Policy Advisor Agent",
+        "human approval",
+    ),
+    "docs/adr/0003-web-based-experience.md": (
+        "Web-first",
+        "Mobile Web",
+        "Native iOS app",
+        "Native Android app",
+    ),
+}
+
 FORBIDDEN_NEW_PATH_PARTS = {
     "prod",
     "production",
     "secrets",
 }
+
+FORBIDDEN_CONTENT_PATTERNS = (
+    "BEGIN " + "PRIVATE KEY",
+    "AWS_" + "SECRET_ACCESS_KEY",
+    "AZURE_" + "CLIENT_SECRET=",
+    "GOOGLE_" + "APPLICATION_CREDENTIALS=",
+)
 
 
 def fail(message: str) -> int:
@@ -49,10 +107,15 @@ def validate_required_files() -> int:
     return 0
 
 
-def validate_readme_not_modified() -> int:
-    changed_files = set(git_diff_name_only("--cached")) | set(git_diff_name_only())
-    if "README.md" in changed_files:
-        return fail("README.md must not be modified by the minimal repo contract")
+def validate_required_text() -> int:
+    violations: list[str] = []
+    for rel_path, required_terms in REQUIRED_TEXT.items():
+        text = (ROOT / rel_path).read_text(encoding="utf-8")
+        for term in required_terms:
+            if term not in text:
+                violations.append(f"{rel_path} missing {term!r}")
+    if violations:
+        return fail("Required contract text missing: " + "; ".join(violations))
     return 0
 
 
@@ -73,18 +136,34 @@ def validate_no_production_config_added() -> int:
     return 0
 
 
+def validate_no_obvious_secrets() -> int:
+    violations: list[str] = []
+    for rel_path in REQUIRED_FILES:
+        path = ROOT / rel_path
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for pattern in FORBIDDEN_CONTENT_PATTERNS:
+            if pattern in text:
+                violations.append(f"{rel_path}: {pattern}")
+    if violations:
+        return fail("Forbidden secret-like content found: " + ", ".join(violations))
+    return 0
+
+
 def main() -> int:
     checks = (
         validate_required_files,
-        validate_readme_not_modified,
+        validate_required_text,
         validate_no_production_config_added,
+        validate_no_obvious_secrets,
     )
     for check in checks:
         result = check()
         if result != 0:
             return result
 
-    print("Repository contract validation passed.")
+    print("Cloud-360 repository contract validation passed.")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Replace outdated placeholder README with Cloud-360 platform positioning and repository contract entry points.
- Add Cloud-360 SDD baseline: SRS, system architecture, user stories, and ADRs.
- Document the updated requirements: draw.io / diagrams.net AI co-editing, AWS/GCP/Azure MCP+SDK+CLI+Skills integration, AI Chat operations, Agentic AI operations, security posture/policy advisory, and Web-based desktop/mobile experience.
- Extend repository contract validation to require the new specification documents and guard against obvious secret-like content.

## Test Plan
- [x] `python scripts/validate_repo_contract.py`
- [x] `git diff --check`
- [x] `python -m py_compile scripts/validate_repo_contract.py`

## Risk
- Documentation-only SDD update plus validation script update.
- No production configuration, credentials, deployment settings, Terraform state, or cloud write operations added.
- `feature/cloud_architecture` remains read-only and was not modified.