### PR TITLE
docs: add MCP and Skill management specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cloud-360 的目標是提供一個 Web-first 的多雲管理與設計工作台�
 - 將確認後的架構轉成 Terraform / OpenTofu 模組草稿。
 - 透過 Agentic AI 主動檢查成本、安全、效能、可用性與維運風險。
 - 透過 MCP / SDK / CLI / Skills 安全地整合雲平台管理能力。
+- 內建 MCP 與 Skill 管理功能，讓平台可治理工具目錄、版本、權限、啟用狀態與審批流程。
 
 ## Core Modules
 
@@ -53,6 +54,11 @@ Cloud-360 的目標是提供一個 Web-first 的多雲管理與設計工作台�
    - 產生 least-privilege、Policy-as-Code、IaC patch 與 remediation plan 建議。
    - 高風險修復必須通過 human approval gate。
 
+8. **MCP & Skill Management**
+   - 管理 MCP servers、tools、AI Skills、cloud provider connectors 與 reusable workflows。
+   - 支援註冊、啟用/停用、版本控管、權限範圍、健康檢查、相依性檢查與審批流程。
+   - 將工具能力納入 Agent Routing Layer，讓 AI 能安全選用合適工具執行 read-only 分析或經審批後的維運操作。
+
 ## Web-Based Desktop and Mobile Experience
 
 Cloud-360 是 Web-first 平台，第一階段不做 native iOS / Android app。
@@ -79,9 +85,23 @@ Cloud-360 透過以下方式整合雲平台：
 - Cloud CLIs
 - Terraform / OpenTofu providers
 - AI Skills
+- MCP / Skill Registry
 - Cloud-native monitoring, billing, IAM, policy and security APIs
 
 Read-only 查詢與分析可直接執行；write / delete / deploy / permission change / production-impacting action 必須先產生 plan、impact、rollback strategy，並通過 human approval gate。
+
+## MCP & Skill Management
+
+Cloud-360 內建 MCP 與 Skill 管理功能，用來治理平台可呼叫的工具能力。
+
+核心能力：
+
+- MCP Server Registry：登錄 AWS / GCP / Azure / internal tools MCP server。
+- Skill Catalog：管理 reusable AI Skills，例如 FinOps 分析、安全檢查、Terraform 產生、incident triage。
+- Tool Permission Model：定義每個 tool / skill 的 read-only、write、deploy、delete、permission-change 風險等級。
+- Versioning & Approval：管理版本、變更紀錄、啟用/停用與審批。
+- Health Check：檢查 MCP server 可用性、schema、auth scope、latency 與錯誤率。
+- Agent Routing Integration：讓 Routing Agent 可根據任務、權限、風險與上下文選擇合適 MCP / Skill。
 
 ## Documentation
 
@@ -91,6 +111,7 @@ Read-only 查詢與分析可直接執行；write / delete / deploy / permission 
 - [ADR 0001: Repository Scope](docs/adr/0001-repo-scope.md)
 - [ADR 0002: Agent Routing Layer](docs/adr/0002-agent-routing-layer.md)
 - [ADR 0003: Web-Based Desktop and Mobile Experience](docs/adr/0003-web-based-experience.md)
+- [ADR 0004: MCP and Skill Management](docs/adr/0004-mcp-skill-management.md)
 
 ## Repository Contract
 

--- a/docs/adr/0004-mcp-skill-management.md
+++ b/docs/adr/0004-mcp-skill-management.md
@@ -1,0 +1,92 @@
+# ADR 0004: MCP and Skill Management
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+Cloud-360 depends on MCP servers, MCP tools, cloud SDK/CLI wrappers, Terraform/OpenTofu utilities and reusable AI Skills to operate across AWS, GCP and Azure. These tool capabilities must be governed like platform infrastructure, not treated as ad-hoc prompt helpers.
+
+Without a management layer, agents could select tools with unclear permissions, outdated schemas, unhealthy endpoints or excessive authorization scope.
+
+## Decision
+
+Cloud-360 will include a first-class **MCP & Skill Management** capability.
+
+The platform will maintain registries for:
+
+- MCP servers
+- MCP tools
+- AI Skills
+- Cloud SDK / CLI wrappers
+- Terraform / OpenTofu and security scanning tools
+- Internal platform tools and workflows
+
+Each registry entry must track:
+
+- name
+- description
+- owner
+- version
+- enabled / disabled / deprecated status
+- environment scope
+- auth scope
+- risk level
+- dependencies
+- health check status
+- change history
+- approval state
+
+## Permission and Risk Classification
+
+Every MCP tool and Skill must be classified as one or more of:
+
+- read-only
+- write
+- deploy
+- delete
+- permission-change
+- production-impacting
+
+Read-only tools may be executed after policy classification. High-risk tools require approval before execution or before enablement.
+
+## Agent Routing Integration
+
+The Agent Routing Layer must consult the MCP / Skill Registry before selecting a tool. Tool selection must consider:
+
+- user intent
+- workspace/project context
+- cloud provider and region
+- required permission scope
+- tool health
+- tool version
+- approval requirement
+- audit requirements
+
+## Health Checks
+
+Cloud-360 must be able to check:
+
+- MCP server availability
+- tool schema compatibility
+- authentication scope
+- latency
+- error rate
+- last successful invocation
+- dependency availability
+
+## Guardrails
+
+- No plaintext secrets in registry configuration.
+- Expanding auth scope requires approval.
+- Adding high-risk tools requires approval.
+- Disabling critical tools requires impact analysis and rollback plan.
+- Tool execution must write audit records.
+- Agent responses must explain tool selection at a summary level while redacting sensitive payloads.
+
+## Consequences
+
+- Cloud-360 can safely grow its tool ecosystem.
+- Agents gain a governed source of truth for tool selection.
+- Operators can troubleshoot MCP / Skill health and permission issues.
+- Security reviewers can audit tool scope and high-risk capabilities.

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -15,6 +15,7 @@ flowchart TB
     Desktop --> FinOpsUI[FinOps Dashboard]
     Desktop --> SecUI[Security Posture Dashboard]
     Desktop --> OpsUI[Operations Dashboard]
+    Desktop --> ToolAdmin[MCP / Skill Management Console]
 
     Mobile --> MobileChat[Mobile Web AI Chat]
     Mobile --> Alerts[Alerts / Findings]
@@ -28,6 +29,7 @@ flowchart TB
     FinOpsUI --> APIGW
     SecUI --> APIGW
     OpsUI --> APIGW
+    ToolAdmin --> APIGW
     MobileChat --> APIGW
     Alerts --> APIGW
     ApprovalUI --> APIGW
@@ -43,6 +45,7 @@ flowchart TB
     Backend --> Audit[(Audit Log)]
     Backend --> Policy[Policy / Permission Engine]
     Backend --> Approval[Human Approval Gate]
+    Backend --> ToolRegistry[(MCP / Skill Registry)]
 
     Router --> Intent[Intent Parser Agent]
     Router --> Design[Design Agent]
@@ -53,6 +56,7 @@ flowchart TB
     Router --> Security[Security Policy Advisor Agent]
     Router --> ToolExec[Tool Execution Agent]
     Router --> Guardrail[Guardrail Agent]
+    Router --> ToolManager[MCP / Skill Manager Agent]
 
     DrawIO --> DiagramAdapter[draw.io XML Adapter]
     DiagramAdapter --> ArchGraph[Internal Architecture Graph]
@@ -63,10 +67,14 @@ flowchart TB
     ArchGraph --> Ops
     ArchGraph --> Security
 
+    ToolManager --> ToolRegistry
+    ToolManager --> Integration
+    ToolExec --> ToolRegistry
     ToolExec --> Integration[Cloud Operation Integration Layer]
 
     Integration --> MCP[MCP Servers]
     Integration --> Skills[AI Skills]
+    Integration --> ToolHealth[MCP / Skill Health Checks]
     Integration --> SDK[Cloud SDKs]
     Integration --> CLI[Cloud CLIs]
     Integration --> IaCTools[Terraform / OpenTofu / tfsec / trivy / Checkov]
@@ -95,7 +103,8 @@ flowchart TB
 3. **Agentic AI with guardrails**：Agent 可主動分析與建議，但高風險操作需 human approval。
 4. **Diagram as structured context**：draw.io 圖面需轉為 internal architecture graph，供 agents 使用。
 5. **Cloud operations through controlled integration layer**：所有 AWS/GCP/Azure 操作經 MCP / SDK / CLI / Skills abstraction。
-6. **No secret leakage**：secrets 不得進入 Git、log、prompt、artifact 或 final report。
+6. **MCP / Skill lifecycle governance**：MCP servers、tools 與 Skills 必須有 registry、version、owner、permission scope、health check 與 approval workflow。
+7. **No secret leakage**：secrets 不得進入 Git、log、prompt、artifact 或 final report。
 
 ## Agent Routing Example
 

--- a/docs/srs/cloud-360-srs.md
+++ b/docs/srs/cloud-360-srs.md
@@ -8,7 +8,7 @@
 
 Cloud-360 是專為雲端架構師、SRE、FinOps 與 Security 團隊設計的 AI-native 多雲架構與維運管理平台。
 
-平台深度整合 LLM、多智能體協作框架、MCP servers、Cloud SDKs、Cloud CLIs、Terraform / OpenTofu 與可重用 Skills，提供涵蓋 AWS、GCP、Azure 的端到端生命週期管理能力。
+平台深度整合 LLM、多智能體協作框架、MCP servers、Cloud SDKs、Cloud CLIs、Terraform / OpenTofu 與可重用 Skills，並提供 MCP 與 Skill 管理功能，提供涵蓋 AWS、GCP、Azure 的端到端生命週期管理能力。
 
 ## 2. Target Users
 
@@ -97,6 +97,21 @@ Required capabilities:
 - 針對 findings 產生 severity、evidence、impact、recommended policy、remediation plan、IaC patch suggestion、verification command、rollback strategy。
 - 支援 Policy-as-Code 建議，例如 OPA/Rego、Sentinel、Azure Policy、GCP Org Policy、AWS Config rule。
 
+### H. MCP & Skill Management
+
+Cloud-360 需提供 MCP servers、MCP tools、AI Skills 與 cloud provider connectors 的集中管理功能。
+
+Required capabilities:
+
+- MCP Server Registry：登錄、設定、啟用/停用與檢查 MCP servers。
+- Tool Catalog：列出 MCP tools、cloud SDK/CLI wrappers、Terraform tools 與 internal tools。
+- Skill Catalog：管理 reusable AI Skills，例如 architecture design、FinOps、security posture review、Terraform generation、incident response。
+- Permission & Risk Model：針對每個 MCP tool / Skill 標示 read-only、write、deploy、delete、permission-change、production-impacting 風險等級。
+- Versioning：記錄版本、schema、owner、相依性、變更紀錄與 rollback target。
+- Health Check：檢查 MCP server availability、tool schema、auth scope、latency、error rate 與最近執行狀態。
+- Approval Workflow：新增、升級、停用高風險 MCP / Skill 或擴權時需 human approval。
+- Agent Routing Integration：Routing Agent 需可依任務、上下文、風險與權限選擇合適 MCP / Skill。
+
 ## 4. User Experience Requirements
 
 ### Desktop Web
@@ -154,6 +169,7 @@ Integration types:
 - Cloud APIs
 - Terraform / OpenTofu providers
 - AI Skills
+- MCP / Skill Registry and Management APIs
 
 Safety requirements:
 
@@ -173,6 +189,7 @@ Safety requirements:
 - Reproducible IaC generation
 - Clear separation between recommendation and execution
 - Responsive Web support for desktop, tablet and mobile browsers
+- Governed MCP / Skill lifecycle management
 
 ## 8. Initial Out of Scope
 

--- a/docs/user-stories/core-pillars.md
+++ b/docs/user-stories/core-pillars.md
@@ -217,3 +217,56 @@ Acceptance criteria:
 - Shows plan, affected resources, risk, impact and rollback.
 - High-risk approval requires MFA, passkey or WebAuthn.
 - Records audit log and supports timeout/escalation.
+
+## I. MCP & Skill Management
+
+### I1. MCP Server Registry
+
+As a platform engineer, I want to register and manage MCP servers so that Cloud-360 can safely expose external and internal tools to agents.
+
+Acceptance criteria:
+
+- Supports server name, endpoint/transport, owner, environment, auth scope, enabled status and version.
+- Supports health checks for availability, schema compatibility, latency and recent errors.
+- Disallows secrets in stored configuration or logs.
+
+### I2. Skill Catalog
+
+As an AI platform operator, I want to manage reusable AI Skills so that agents can reuse approved workflows.
+
+Acceptance criteria:
+
+- Tracks skill name, domain, owner, version, description, required tools, risk level and change log.
+- Supports enable, disable, deprecate and rollback states.
+- Shows dependencies between skills, MCP tools, SDK/CLI wrappers and cloud providers.
+
+### I3. Tool Permission and Risk Model
+
+As a security reviewer, I want every MCP tool and Skill to have a permission/risk classification.
+
+Acceptance criteria:
+
+- Classifies tools as read-only, write, deploy, delete, permission-change or production-impacting.
+- High-risk tools require approval before enablement or execution.
+- Agent Routing Layer must use this classification before selecting tools.
+
+### I4. MCP / Skill Approval Workflow
+
+As a platform owner, I want risky MCP/Skill changes to require approval.
+
+Acceptance criteria:
+
+- Adding a new high-risk tool requires review.
+- Expanding auth scope requires approval.
+- Disabling critical tools requires impact summary and rollback plan.
+- All changes are written to audit log.
+
+### I5. Agent Tool Selection Observability
+
+As an SRE, I want to see why an agent selected a specific MCP tool or Skill.
+
+Acceptance criteria:
+
+- Shows selected tool/skill, reason, input summary, permission level, approval status and execution result.
+- Redacts secrets and sensitive payloads.
+- Links tool execution back to user request, agent trace and audit log.

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -19,6 +19,7 @@ REQUIRED_FILES = (
     "docs/adr/0001-repo-scope.md",
     "docs/adr/0002-agent-routing-layer.md",
     "docs/adr/0003-web-based-experience.md",
+    "docs/adr/0004-mcp-skill-management.md",
     "scripts/validate_repo_contract.py",
 )
 
@@ -32,6 +33,7 @@ REQUIRED_TEXT = {
         "Mobile Web",
         "Cloud Security Posture",
         "human approval gate",
+        "MCP & Skill Management",
     ),
     "docs/srs/cloud-360-srs.md": (
         "AI Multi-Cloud Operations",
@@ -39,18 +41,21 @@ REQUIRED_TEXT = {
         "Mobile Web",
         "MCP servers",
         "Terraform / OpenTofu",
+        "MCP & Skill Management",
     ),
     "docs/architecture/system-architecture.md": (
         "Agent Routing Layer",
         "Cloud Operation Integration Layer",
         "draw.io",
         "Security Policy Advisor Agent",
+        "MCP / Skill Registry",
     ),
     "docs/user-stories/core-pillars.md": (
         "Architecture Design",
         "Cost Estimation & FinOps",
         "Cloud Security Posture",
         "Mobile Web",
+        "MCP & Skill Management",
     ),
     "docs/adr/0001-repo-scope.md": (
         "Spec-Driven Development",
@@ -67,6 +72,12 @@ REQUIRED_TEXT = {
         "Mobile Web",
         "Native iOS app",
         "Native Android app",
+    ),
+    "docs/adr/0004-mcp-skill-management.md": (
+        "MCP and Skill Management",
+        "Permission and Risk Classification",
+        "Agent Routing Integration",
+        "Health Checks",
     ),
 }
 


### PR DESCRIPTION
## Summary
- Add MCP and Skill Management as a first-class Cloud-360 capability.
- Define MCP Server Registry, Tool Catalog, Skill Catalog, permission/risk model, versioning, health checks, approval workflow, and agent routing integration.
- Add ADR 0004 for MCP and Skill lifecycle governance.
- Update README, SRS, system architecture, user stories, and repo contract validation.

## Test Plan
- [x] `python -m py_compile scripts/validate_repo_contract.py`
- [x] `python scripts/validate_repo_contract.py`
- [x] `git diff --check`

## Risk
- Documentation and validation-only change.
- No production configuration, credentials, cloud execution, or destructive operations added.
- `feature/cloud_architecture` remains read-only and was not modified.
