### PR TITLE
docs: add system architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Cloud-360 內建 MCP 與 Skill 管理功能，用來治理平台可呼叫的工�
 
 ## Documentation
 
+Cloud-360 的 `docs/` 文件必須同時包含中文版與英文版。
+All Cloud-360 documents under `docs/` must include both Chinese and English versions.
+
+- [Documentation Index](docs/README.md)
 - [System Requirement Specification](docs/srs/cloud-360-srs.md)
 - [System Architecture](docs/architecture/system-architecture.md)
 - [Core Pillars User Stories](docs/user-stories/core-pillars.md)
@@ -198,6 +202,7 @@ Cloud-360 內建 MCP 與 Skill 管理功能，用來治理平台可呼叫的工�
 - [ADR 0002: Agent Routing Layer](docs/adr/0002-agent-routing-layer.md)
 - [ADR 0003: Web-Based Desktop and Mobile Experience](docs/adr/0003-web-based-experience.md)
 - [ADR 0004: MCP and Skill Management](docs/adr/0004-mcp-skill-management.md)
+- [ADR 0005: Bilingual Documentation](docs/adr/0005-bilingual-documentation.md)
 
 ## Repository Contract
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,92 @@ Cloud-360 的目標是提供一個 Web-first 的多雲管理與設計工作台�
 - 透過 MCP / SDK / CLI / Skills 安全地整合雲平台管理能力。
 - 內建 MCP 與 Skill 管理功能，讓平台可治理工具目錄、版本、權限、啟用狀態與審批流程。
 
+## System Architecture
+
+```mermaid
+flowchart TB
+    User[Cloud Architect / SRE / FinOps / Security] --> Browser[Web Browser]
+
+    Browser --> Desktop[Desktop Web Full Workspace]
+    Browser --> Mobile[Mobile Web / Responsive Web / PWA]
+
+    Desktop --> Chat[AI Chat]
+    Desktop --> DrawIO[draw.io / diagrams.net Canvas]
+    Desktop --> IaCEditor[Terraform / Policy Editor]
+    Desktop --> Dashboards[FinOps / Security / Ops Dashboards]
+    Desktop --> ToolAdmin[MCP / Skill Management Console]
+
+    Mobile --> MobileChat[Mobile Web AI Chat]
+    Mobile --> Alerts[Alerts / Findings]
+    Mobile --> ApprovalUI[Approval Workflow]
+    Mobile --> Digest[Cloud Health Digest]
+    Mobile --> DiagramRO[Readonly Diagram View]
+
+    Chat --> APIGW[API Gateway]
+    DrawIO --> APIGW
+    IaCEditor --> APIGW
+    Dashboards --> APIGW
+    ToolAdmin --> APIGW
+    MobileChat --> APIGW
+    Alerts --> APIGW
+    ApprovalUI --> APIGW
+    Digest --> APIGW
+    DiagramRO --> APIGW
+
+    APIGW --> Auth[Auth / RBAC / MFA / WebAuthn]
+    Auth --> Backend[Backend Service Python or Java]
+
+    Backend --> Router[Agent Routing Layer]
+    Backend --> Memory[(Shared Context / Memory)]
+    Backend --> ArtifactStore[(Artifact Store)]
+    Backend --> Audit[(Audit Log)]
+    Backend --> Policy[Policy / Permission Engine]
+    Backend --> Approval[Human Approval Gate]
+    Backend --> ToolRegistry[(MCP / Skill Registry)]
+
+    Router --> Design[Design Agent]
+    Router --> Selector[Component Selection Agent]
+    Router --> FinOps[FinOps Agent]
+    Router --> IaC[IaC Agent]
+    Router --> Ops[Operations Agent]
+    Router --> Security[Security Policy Advisor Agent]
+    Router --> ToolManager[MCP / Skill Manager Agent]
+    Router --> ToolExec[Tool Execution Agent]
+    Router --> Guardrail[Guardrail Agent]
+
+    DrawIO --> DiagramAdapter[draw.io XML Adapter]
+    DiagramAdapter --> ArchGraph[Internal Architecture Graph]
+    ArchGraph --> Memory
+    ArchGraph --> Design
+    ArchGraph --> FinOps
+    ArchGraph --> IaC
+    ArchGraph --> Ops
+    ArchGraph --> Security
+
+    ToolManager --> ToolRegistry
+    ToolExec --> ToolRegistry
+    ToolExec --> Integration[Cloud Operation Integration Layer]
+
+    Integration --> MCP[MCP Servers]
+    Integration --> Skills[AI Skills]
+    Integration --> SDK[Cloud SDKs]
+    Integration --> CLI[Cloud CLIs]
+    Integration --> IaCTools[Terraform / OpenTofu / Security Scanners]
+
+    Integration --> AWS[AWS APIs]
+    Integration --> GCP[GCP APIs]
+    Integration --> Azure[Azure APIs]
+
+    AWS --> Agentic[Agentic AI Operations]
+    GCP --> Agentic
+    Azure --> Agentic
+    Agentic --> Router
+    Agentic --> Alerts
+    Agentic --> Digest
+```
+
+完整架構說明請見 [System Architecture](docs/architecture/system-architecture.md)。
+
 ## Core Modules
 
 1. **Architecture Design**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Cloud-360 Documentation
+
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
+Cloud-360 的 `docs/` 文件必須同時包含中文版與英文版。
+
+文件規則：
+
+- 每個 `docs/**/*.md` 文件必須包含 `## 中文版`。
+- 每個 `docs/**/*.md` 文件必須包含 `## English Version`。
+- 中文版用於 Danniel 與中文團隊快速討論。
+- 英文版用於國際協作、技術審查、AI agent 與外部 contributor。
+- 若只先完成其中一種語言，PR 不應合併到 `main`。
+
+主要文件：
+
+- [SRS](srs/cloud-360-srs.md)
+- [System Architecture](architecture/system-architecture.md)
+- [Core Pillars User Stories](user-stories/core-pillars.md)
+- [ADR 0001: Repository Scope](adr/0001-repo-scope.md)
+- [ADR 0002: Agent Routing Layer](adr/0002-agent-routing-layer.md)
+- [ADR 0003: Web-Based Experience](adr/0003-web-based-experience.md)
+- [ADR 0004: MCP and Skill Management](adr/0004-mcp-skill-management.md)
+- [ADR 0005: Bilingual Documentation](adr/0005-bilingual-documentation.md)
+
+## English Version
+
+All Cloud-360 documentation under `docs/` must include both Chinese and English versions.
+
+Documentation rules:
+
+- Every `docs/**/*.md` document must include `## 中文版`.
+- Every `docs/**/*.md` document must include `## English Version`.
+- The Chinese version supports Danniel and Chinese-speaking teams.
+- The English version supports international collaboration, technical review, AI agents, and external contributors.
+- If a document only contains one language, the pull request should not be merged into `main`.
+
+Main documents:
+
+- [SRS](srs/cloud-360-srs.md)
+- [System Architecture](architecture/system-architecture.md)
+- [Core Pillars User Stories](user-stories/core-pillars.md)
+- [ADR 0001: Repository Scope](adr/0001-repo-scope.md)
+- [ADR 0002: Agent Routing Layer](adr/0002-agent-routing-layer.md)
+- [ADR 0003: Web-Based Experience](adr/0003-web-based-experience.md)
+- [ADR 0004: MCP and Skill Management](adr/0004-mcp-skill-management.md)
+- [ADR 0005: Bilingual Documentation](adr/0005-bilingual-documentation.md)

--- a/docs/adr/0001-repo-scope.md
+++ b/docs/adr/0001-repo-scope.md
@@ -1,5 +1,10 @@
 # ADR 0001: Cloud-360 Repository Scope
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 - Status: Accepted
 - Date: 2026-05-02
 
@@ -64,3 +69,11 @@ All write/delete/deploy/permission-changing cloud operations must include:
 - SDD documents become the source of truth for initial implementation.
 - CI validates that required contract documents exist and contain key platform concepts.
 - Future implementation work should extend this contract through new ADRs and tests.
+
+## English Version
+
+Decision: this repository tracks the Cloud-360 Spec-Driven Development baseline, including the product README, SRS, architecture documents, user stories, ADRs, repository validation script, and baseline CI.
+
+The repository scope includes AWS/GCP/Azure multi-cloud architecture design, component selection, FinOps, Terraform/OpenTofu generation, operations optimization, AI Chat driven cloud management, Agentic AI operations, security posture and policy advisory, draw.io/diagrams.net architecture canvas, Web-based desktop/mobile experience, and MCP/Skill lifecycle governance.
+
+Guardrails: the repository must not contain plaintext cloud credentials, production-specific deployment configuration, direct production Terraform state, autonomous destructive cloud actions, or unreviewed production-impacting changes. The `feature/cloud_architecture` branch remains read-only unless explicitly authorized by Danniel.

--- a/docs/adr/0002-agent-routing-layer.md
+++ b/docs/adr/0002-agent-routing-layer.md
@@ -1,5 +1,10 @@
 # ADR 0002: Agent Routing Layer
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 - Status: Accepted
 - Date: 2026-05-02
 
@@ -59,3 +64,11 @@ Read-only queries may execute after policy classification. High-risk actions req
 - Tool execution is isolated behind policy and approval gates.
 - All recommendations can be traced to source context and tool output.
 - Future agents can be added through ADRs without changing the core platform contract.
+
+## English Version
+
+Decision: Cloud-360 uses an OpenClaw-like Agent Routing Layer to coordinate intent parsing, architecture design, component selection, FinOps, IaC generation, operations review, security policy advisory, tool execution, and guardrails.
+
+Agents share structured context such as user requirements, assumptions, architecture graph, draw.io XML, cost model, selected cloud components, generated IaC, security findings, approval decisions, and audit records.
+
+Read-only operations may run after policy classification. High-risk actions such as write, delete, deploy, permission changes, firewall changes, KMS/storage policy changes, production Terraform apply, or scaling changes require human approval.

--- a/docs/adr/0003-web-based-experience.md
+++ b/docs/adr/0003-web-based-experience.md
@@ -1,5 +1,10 @@
 # ADR 0003: Web-Based Desktop and Mobile Experience
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 - Status: Accepted
 - Date: 2026-05-02
 
@@ -70,3 +75,11 @@ All approvals and rejections must be written to audit log.
 - The platform can share backend, API, authentication, RBAC, audit log and agent context across desktop and mobile web.
 - UI implementation must prioritize responsive layout and mobile-readable summaries.
 - Native app work can be reconsidered later through a separate ADR.
+
+## English Version
+
+Decision: Cloud-360 is delivered as a Web-first platform. First-phase UI surfaces include Desktop Web, Tablet Web, Mobile Web, Responsive Web, and optional PWA capabilities. Native iOS and Android applications are out of the initial scope.
+
+Desktop Web provides the full workspace: AI Chat, draw.io/diagrams.net co-editing, Terraform/policy editor, FinOps dashboard, security posture dashboard, operations dashboard, agent workflow trace, audit log, and approval gate management.
+
+Mobile Web is an operations companion for AI Chat, alerts, approval/rejection workflow, cloud health digest, cost/security/operations findings, readonly architecture diagrams, and incident quick triage.

--- a/docs/adr/0004-mcp-skill-management.md
+++ b/docs/adr/0004-mcp-skill-management.md
@@ -1,5 +1,10 @@
 # ADR 0004: MCP and Skill Management
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 - Status: Accepted
 - Date: 2026-05-02
 
@@ -90,3 +95,11 @@ Cloud-360 must be able to check:
 - Agents gain a governed source of truth for tool selection.
 - Operators can troubleshoot MCP / Skill health and permission issues.
 - Security reviewers can audit tool scope and high-risk capabilities.
+
+## English Version
+
+Decision: Cloud-360 includes first-class MCP and Skill Management. The platform maintains registries for MCP servers, MCP tools, AI Skills, cloud SDK/CLI wrappers, Terraform/OpenTofu tools, security scanners, internal platform tools, and workflows.
+
+Each registry entry tracks name, description, owner, version, status, environment scope, auth scope, risk level, dependencies, health check status, change history, and approval state.
+
+Every MCP tool and Skill must be classified as read-only, write, deploy, delete, permission-change, and/or production-impacting. The Agent Routing Layer must consult the registry before selecting tools. High-risk tools require approval before enablement or execution.

--- a/docs/adr/0005-bilingual-documentation.md
+++ b/docs/adr/0005-bilingual-documentation.md
@@ -1,0 +1,66 @@
+# ADR 0005: Bilingual Documentation
+
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+Cloud-360 會由中文使用者、國際協作者、AI agent、dev-agent 與不同技術角色共同閱讀與維護。為避免規格理解落差，`docs/` 文件必須同時提供中文版與英文版。
+
+## Decision
+
+所有 `docs/**/*.md` 文件必須包含：
+
+- `## 中文版`
+- `## English Version`
+
+文件可以採同檔雙語模式，不必拆成兩個檔案。第一階段採同檔雙語，降低文件同步成本。
+
+## Requirements
+
+- 新增或修改 docs 文件時，必須同步更新中文與英文內容。
+- README 可以保持產品入口，但需連到雙語 docs。
+- SRS、Architecture、User Stories、ADR 都必須雙語。
+- CI 的 repository contract validation 必須檢查 docs 文件是否包含雙語章節。
+
+## Consequences
+
+- 中文團隊可以快速討論產品與架構。
+- 英文 reviewer、外部 contributor 與 AI agent 可以理解規格。
+- 文件變更成本略增，但能降低跨語言誤解風險。
+
+## English Version
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+Cloud-360 documentation will be read and maintained by Chinese-speaking users, international collaborators, AI agents, dev-agents, and different technical roles. To avoid requirement and architecture misunderstandings, all documentation under `docs/` must provide both Chinese and English versions.
+
+## Decision
+
+Every `docs/**/*.md` document must include:
+
+- `## 中文版`
+- `## English Version`
+
+The documentation may use a single-file bilingual format. The initial phase uses the single-file bilingual format to reduce synchronization overhead.
+
+## Requirements
+
+- When adding or modifying docs, both Chinese and English content must be updated together.
+- README may remain the product entry point, but it should link to bilingual docs.
+- SRS, Architecture, User Stories, and ADRs must all be bilingual.
+- CI repository contract validation must check whether docs files contain bilingual sections.
+
+## Consequences
+
+- Chinese-speaking teams can discuss product and architecture quickly.
+- English reviewers, external contributors, and AI agents can understand the specification.
+- Documentation changes become slightly more expensive, but cross-language misunderstanding risk is reduced.

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -1,5 +1,10 @@
 # Cloud-360 System Architecture
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 ## High-Level Architecture
 
 ```mermaid
@@ -156,3 +161,13 @@ flowchart TD
     TF --> Report
     Scan --> Report
 ```
+
+## English Version
+
+Cloud-360 uses a Web-first architecture with Desktop Web and Mobile Web entry points. The frontend connects to an API Gateway, authentication/RBAC/MFA/WebAuthn, and a backend service.
+
+The backend coordinates an Agent Routing Layer, shared memory, artifact storage, audit logs, policy engine, human approval gate, and MCP/Skill Registry. Specialized agents include Design, Component Selection, FinOps, IaC, Operations, Security Policy Advisor, MCP/Skill Manager, Tool Execution, and Guardrail agents.
+
+The draw.io/diagrams.net canvas is parsed through a draw.io XML adapter into an internal architecture graph. That graph becomes shared context for Design, FinOps, IaC, Operations, and Security agents.
+
+Cloud operations are executed only through a controlled Cloud Operation Integration Layer that connects MCP servers, AI Skills, cloud SDKs, cloud CLIs, Terraform/OpenTofu, security scanners, and AWS/GCP/Azure APIs. Agentic AI operations can generate findings and recommendations, while high-risk execution requires human approval.

--- a/docs/srs/cloud-360-srs.md
+++ b/docs/srs/cloud-360-srs.md
@@ -1,5 +1,10 @@
 # Cloud-360 System Requirement Specification
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 - Status: Draft v0.1
 - Date: 2026-05-02
 - Owner: Danniel Chung / Anita
@@ -199,3 +204,29 @@ Safety requirements:
 - Storing plaintext cloud credentials
 - Autonomous destructive cloud changes
 - Treating third-party collaborative branches as editable without explicit authorization
+
+## English Version
+
+Cloud-360 is an AI-native multi-cloud architecture, governance, security, and operations platform for Cloud Architects, SRE, FinOps, and Security teams.
+
+The platform integrates LLMs, a multi-agent collaboration framework, MCP servers, cloud SDKs, cloud CLIs, Terraform/OpenTofu, reusable AI Skills, and MCP/Skill management capabilities to support AWS, GCP, and Azure lifecycle management.
+
+Core requirements:
+
+- AI-driven architecture design from natural language requirements.
+- Cross-cloud component selection across AWS, GCP, and Azure.
+- Cost estimation and FinOps analysis, including data egress and interruptible pricing.
+- Terraform/OpenTofu generation with static security scanning.
+- Operations optimization for performance, reliability, cost, SLO/SLA, and modernization.
+- AI Chat driven cloud operations and Agentic AI proactive analysis.
+- Cloud Security Posture and Policy Advisory.
+- MCP and Skill Management covering registry, catalog, risk classification, versioning, health checks, approvals, and Agent Routing integration.
+- Desktop Web as the full workspace and Mobile Web/Responsive Web/PWA as the operations companion.
+
+Out of initial scope:
+
+- Native iOS application.
+- Native Android application.
+- Direct production deployment without approval workflow.
+- Plaintext cloud credentials.
+- Autonomous destructive cloud changes.

--- a/docs/user-stories/core-pillars.md
+++ b/docs/user-stories/core-pillars.md
@@ -1,5 +1,10 @@
 # Cloud-360 Core Pillars User Stories
 
+> 本文件必須同時包含中文版與英文版。
+> This document must include both Chinese and English versions.
+
+## 中文版
+
 ## A. Architecture Design
 
 ### A1. Natural Language to Architecture
@@ -270,3 +275,19 @@ Acceptance criteria:
 - Shows selected tool/skill, reason, input summary, permission level, approval status and execution result.
 - Redacts secrets and sensitive payloads.
 - Links tool execution back to user request, agent trace and audit log.
+
+## English Version
+
+This document defines Cloud-360 user stories across the core platform pillars:
+
+- Architecture Design.
+- Cross-Cloud Component Selection.
+- Cost Estimation and FinOps.
+- Terraform/OpenTofu IaC Generation.
+- Operations Optimization Review.
+- AI Multi-Cloud Operations.
+- Cloud Security Posture and Policy Advisory.
+- Web-Based Desktop and Mobile Experience.
+- MCP and Skill Management.
+
+Each story includes acceptance criteria so implementation work can be validated through Spec-Driven Development. The MCP and Skill Management stories require registries, catalogs, permission/risk classification, approval workflow, and observability for agent tool selection.

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -19,7 +19,9 @@ REQUIRED_FILES = (
     "docs/adr/0001-repo-scope.md",
     "docs/adr/0002-agent-routing-layer.md",
     "docs/adr/0003-web-based-experience.md",
+    "docs/README.md",
     "docs/adr/0004-mcp-skill-management.md",
+    "docs/adr/0005-bilingual-documentation.md",
     "scripts/validate_repo_contract.py",
 )
 
@@ -79,6 +81,16 @@ REQUIRED_TEXT = {
         "Agent Routing Integration",
         "Health Checks",
     ),
+    "docs/adr/0005-bilingual-documentation.md": (
+        "Bilingual Documentation",
+        "## 中文版",
+        "## English Version",
+    ),
+    "docs/README.md": (
+        "Cloud-360 Documentation",
+        "## 中文版",
+        "## English Version",
+    ),
 }
 
 FORBIDDEN_NEW_PATH_PARTS = {
@@ -130,6 +142,21 @@ def validate_required_text() -> int:
     return 0
 
 
+def validate_docs_are_bilingual() -> int:
+    violations: list[str] = []
+    for path in sorted((ROOT / "docs").rglob("*.md")):
+        rel_path = path.relative_to(ROOT).as_posix()
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "## 中文版" not in text or "## English Version" not in text:
+            violations.append(rel_path)
+    if violations:
+        return fail(
+            "Docs must include both '## 中文版' and '## English Version': "
+            + ", ".join(violations)
+        )
+    return 0
+
+
 def validate_no_production_config_added() -> int:
     changed_files = set(git_diff_name_only("--cached")) | set(git_diff_name_only())
     violations: list[str] = []
@@ -166,6 +193,7 @@ def main() -> int:
     checks = (
         validate_required_files,
         validate_required_text,
+        validate_docs_are_bilingual,
         validate_no_production_config_added,
         validate_no_obvious_secrets,
     )


### PR DESCRIPTION
## Summary
- Add a Mermaid system architecture diagram directly to `README.md`.
- The diagram covers Web/Mobile Web entry points, AI Chat, draw.io canvas, API Gateway, backend, Agent Routing Layer, MCP/Skill Registry, Cloud Operation Integration Layer, AWS/GCP/Azure integrations, and Agentic AI Operations.
- Keep the detailed architecture document linked from README for deeper explanation.

## Test Plan
- [x] `python scripts/validate_repo_contract.py`
- [x] `git diff --check`

## Risk
- Documentation-only change.
- No production configuration, credentials, cloud execution, or destructive operations added.
- `feature/cloud_architecture` remains read-only and was not modified.
