### PR TITLE
feat: add branch-naming override layer (PR3)

### DIFF
--- a/.aidlc-overrides/README.md
+++ b/.aidlc-overrides/README.md
@@ -1,0 +1,64 @@
+# Cloud-360 AIDLC Overrides
+
+> Project-specific rules that **layer on top of** upstream AIDLC rules in `.aidlc-rule-details/`.
+> 在 upstream AIDLC rules 之上**疊加**的專案規則層。
+
+## 中文版
+
+### 目的
+
+本目錄存放 Cloud-360 專屬的 AIDLC override 規則。Upstream（`awslabs/aidlc-workflows`）發版時 `.aidlc-rule-details/` 會被整批替換，但 `.aidlc-overrides/` 永遠由本專案維護、永不被 upstream 覆蓋。
+
+### 載入順序與優先權
+
+CLAUDE.md 指示 Claude Code（與其他 AI agent）依下列順序載入規則：
+
+1. `.aidlc-rules/aws-aidlc-rules/core-workflow.md`（AIDLC 入口）
+2. `.aidlc-rule-details/common/`、`.aidlc-rule-details/inception|construction|operations/`、enabled extensions（upstream 規則）
+3. **最後**載入 `.aidlc-overrides/**/*.md`（本目錄）
+
+當 upstream 規則與 override 規則衝突時，**override 永遠勝出**。
+
+### 現有 overrides
+
+| 檔案 | 規範 | 對應 upstream |
+|---|---|---|
+| `branch-naming.md` | Cloud-360 git branch 命名規範 | upstream 無此規則，純疊加 |
+
+### 撰寫新 override 的原則
+
+1. **不修改 `.aidlc-rule-details/`**：upstream 規則保持原狀，便於同步新版本。
+2. **bilingual**：每個 override 檔必須包含 `## 中文版` 與 `## English Version`，對齊 ADR-0005。
+3. **明確標示覆蓋對象**：若 override 是為了改寫 upstream 某條規則，要在檔案內明確說明覆蓋的 upstream 路徑與條目。
+4. **記錄到 audit.md**：新增、移除或修改 override 時，附 audit log entry。
+
+---
+
+## English Version
+
+### Purpose
+
+This directory holds Cloud-360-specific AIDLC override rules. When upstream `awslabs/aidlc-workflows` cuts a new release, `.aidlc-rule-details/` is replaced wholesale; `.aidlc-overrides/` is owned by this project and is never overwritten by upstream.
+
+### Loading Order and Precedence
+
+`CLAUDE.md` instructs Claude Code (and other AI agents) to load rules in this order:
+
+1. `.aidlc-rules/aws-aidlc-rules/core-workflow.md` (AIDLC entry)
+2. `.aidlc-rule-details/common/`, `.aidlc-rule-details/inception|construction|operations/`, and enabled extensions (upstream rules)
+3. **Finally**, load `.aidlc-overrides/**/*.md` (this directory)
+
+When an upstream rule conflicts with an override, **the override always wins**.
+
+### Current Overrides
+
+| File | Rule | Corresponding Upstream |
+|---|---|---|
+| `branch-naming.md` | Cloud-360 git branch naming convention | No upstream equivalent — pure addition |
+
+### Authoring New Overrides
+
+1. **Never modify `.aidlc-rule-details/`**: keep upstream rules untouched so future syncs stay clean.
+2. **Bilingual**: every override file must include `## 中文版` and `## English Version`, aligning with ADR-0005.
+3. **State the override target clearly**: if an override is meant to replace a specific upstream rule, name the upstream path and clause it overrides.
+4. **Log it in audit.md**: add an audit entry whenever an override is added, removed, or modified.

--- a/.aidlc-overrides/branch-naming.md
+++ b/.aidlc-overrides/branch-naming.md
@@ -1,0 +1,130 @@
+# Cloud-360 Branch Naming Convention
+
+> Project override rule. Takes precedence over any conflicting upstream guidance.
+> 專案 override 規則。與 upstream 任何衝突指示相比，本規則優先。
+
+## 中文版
+
+### 規範
+
+所有新建分支必須遵循下列格式：
+
+```
+<uploader>/<type>/<slug>
+```
+
+- `<uploader>`：開分支的人慣用的英文小寫 handle。
+  - Danniel 一律使用 `danniel`。
+  - 其他成員使用各自一致的英文小寫 handle（建議與 GitHub username 一致）。
+- `<type>`：分支用途，限定為下列 conventional commit 類型之一：
+  - `feat` — 新功能
+  - `fix` — bug 修復
+  - `docs` — 文件變更（純 markdown / spec）
+  - `chore` — 雜項（CI、依賴、版本維護）
+  - `refactor` — 重構（行為不變）
+  - `test` — 測試補強或修正
+- `<slug>`：英文小寫，連字號分隔，3–5 個詞概述變更目的。
+
+### 範例
+
+✅ 合規：
+
+| Branch | 用途 |
+|---|---|
+| `danniel/feat/aidlc-docs-migration` | 新功能：搬遷 AIDLC docs |
+| `danniel/fix/agent-routing-bug` | 修復 agent routing 路徑判斷錯誤 |
+| `danniel/docs/srs-update` | SRS 文件更新 |
+| `danniel/chore/dependency-bump` | CI 依賴升級 |
+| `danniel/refactor/skill-registry-split` | 重構 MCP skill registry |
+| `danniel/test/cost-calculator-property-tests` | 補 cost calculator property-based 測試 |
+
+❌ 不合規：
+
+| Branch | 違規原因 |
+|---|---|
+| `feat/aidlc-rules` | 缺少 `<uploader>/` 前綴 |
+| `Danniel/feat/foo` | 大寫 |
+| `danniel/feature/foo` | type 不在限定清單（要 `feat` 不是 `feature`） |
+| `danniel/foo` | 缺少 `<type>/` 段 |
+| `danniel/feat/foo_bar` | slug 用底線而非連字號 |
+
+### 套用範圍
+
+- ✅ 適用：所有從 `main` 建立的新分支。
+- ✅ 適用：long-lived feature branch、stacked PR branch（如 PR2、PR3）。
+- ⏸ 不溯及：在本規則建立前已存在的分支（例如 `feat/aidlc-framework-rules`、`feat/aidlc-docs-migration`）保留原名直到合併。
+- ❌ 不適用：自動產生的分支，例如 `dependabot/*`、`release/*`、tooling 自動 push 的 branch。
+
+### 與 upstream AIDLC rules 的關係
+
+upstream `awslabs/aidlc-workflows` 不規範 git branch 命名，本規則為**純疊加**（無覆蓋對象）。Claude Code 開分支前必須遵循此規則。
+
+### Enforcement
+
+- 人類審查：PR reviewer 在 review 時檢查 branch 名稱。
+- 自動檢查（可選，未強制）：未來可在 `.github/workflows/ci.yml` 加 step，使用 regex `^[a-z0-9-]+/(feat|fix|docs|chore|refactor|test)/[a-z0-9-]+$` 檢查 head branch；本 override 暫不強制 CI 整合，先以 review + Claude Code 自動套用為主。
+- AI agent：Claude Code 與其他 AI agent 在執行 `git checkout -b` / `git switch -c` 之前，必須先確認 branch name 符合此格式。若使用者下達衝突指令，先提醒並請使用者確認。
+
+---
+
+## English Version
+
+### Rule
+
+Every new branch MUST follow this format:
+
+```
+<uploader>/<type>/<slug>
+```
+
+- `<uploader>`: the contributor's lowercase handle.
+  - Danniel always uses `danniel`.
+  - Other members use their own consistent lowercase handle (recommended: GitHub username).
+- `<type>`: the branch purpose, restricted to one of the following conventional commit types:
+  - `feat` — new feature
+  - `fix` — bug fix
+  - `docs` — documentation change (pure markdown / specification)
+  - `chore` — miscellaneous (CI, dependencies, version maintenance)
+  - `refactor` — refactoring (behavior unchanged)
+  - `test` — adding or fixing tests
+- `<slug>`: lowercase English, hyphen-separated, 3–5 words summarizing the change.
+
+### Examples
+
+✅ Compliant:
+
+| Branch | Purpose |
+|---|---|
+| `danniel/feat/aidlc-docs-migration` | New feature: migrating AIDLC docs |
+| `danniel/fix/agent-routing-bug` | Fix incorrect agent routing path |
+| `danniel/docs/srs-update` | SRS document update |
+| `danniel/chore/dependency-bump` | CI dependency upgrade |
+| `danniel/refactor/skill-registry-split` | Refactor MCP skill registry |
+| `danniel/test/cost-calculator-property-tests` | Add property-based tests for the cost calculator |
+
+❌ Non-compliant:
+
+| Branch | Violation |
+|---|---|
+| `feat/aidlc-rules` | Missing `<uploader>/` prefix |
+| `Danniel/feat/foo` | Uppercase |
+| `danniel/feature/foo` | Type not in the allowed set (use `feat`, not `feature`) |
+| `danniel/foo` | Missing `<type>/` segment |
+| `danniel/feat/foo_bar` | Slug uses underscores instead of hyphens |
+
+### Scope
+
+- ✅ Applies: every new branch created from `main`.
+- ✅ Applies: long-lived feature branches and stacked PR branches (e.g. PR2, PR3).
+- ⏸ Not retroactive: branches created before this rule (e.g. `feat/aidlc-framework-rules`, `feat/aidlc-docs-migration`) keep their existing names until merged.
+- ❌ Does not apply: auto-generated branches such as `dependabot/*`, `release/*`, or tool-pushed branches.
+
+### Relationship to Upstream AIDLC Rules
+
+Upstream `awslabs/aidlc-workflows` does not specify a git branch naming convention. This rule is a **pure addition** (no upstream rule is overridden). Claude Code must follow this rule whenever it creates a new branch.
+
+### Enforcement
+
+- Human review: PR reviewers check branch names during review.
+- Automated check (optional, not yet enforced): a future `.github/workflows/ci.yml` step could validate the head branch with the regex `^[a-z0-9-]+/(feat|fix|docs|chore|refactor|test)/[a-z0-9-]+$`. This override does not require CI integration yet — review + AI agent self-enforcement is enough for now.
+- AI agents: Claude Code and other AI agents MUST check that a branch name matches this format before running `git checkout -b` or `git switch -c`. If the user issues a conflicting instruction, surface the conflict and ask for confirmation before proceeding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Cloud-360 是 AI-native multi-cloud architecture & operations platform，支援 
    - `common/question-format-guide.md`
 3. 掃描 `.aidlc-rule-details/extensions/`，僅載入 `*.opt-in.md`（lightweight），完整 rules 在使用者 opt-in 後再載入
 4. 對於**無 opt-in 檔案**的 extension（例如 `bilingual-docs/`），**永遠強制套用**，立即載入完整規則
+5. **最後**載入 `.aidlc-overrides/**/*.md`（專案 override 層）。當 override 與 upstream 規則衝突時，**override 永遠勝出**。詳見 [`.aidlc-overrides/README.md`](.aidlc-overrides/README.md)。
 
 **三階段**：
 - 🔵 Inception — workspace detection、requirements analysis、user stories、application design
@@ -69,11 +70,13 @@ Cloud-360 是 AI-native multi-cloud architecture & operations platform，支援 
 3. **內容驗證**：建檔前依 `common/content-validation.md` 驗證 Mermaid、ASCII 圖、特殊字元。
 4. **雙語產出**：所有 `aidlc-docs/**/*.md` 一定要同時有 `## 中文版` 與 `## English Version`。
 5. **High-risk action**：任何 production write / IaC apply / IAM 變更必須先給 plan + impact + rollback，並通過 human approval gate。
+6. **Branch naming**：在 `git checkout -b` / `git switch -c` 之前，**必須**先讀 [`.aidlc-overrides/branch-naming.md`](.aidlc-overrides/branch-naming.md) 並產出符合 `<uploader>/<type>/<slug>` 的 branch 名稱（type ∈ {feat, fix, docs, chore, refactor, test}）。Danniel 開的 branch 一律以 `danniel/` 開頭。如果使用者下達衝突指令（例如直接給一個不合規的 branch 名稱），先提醒衝突並請使用者確認。
 
 ### 7. AIDLC 升級
 
 - 升級時對照 `https://github.com/awslabs/aidlc-workflows/releases`，更新 `.aidlc-rule-details/VERSION` 並重新複製 `aws-aidlc-rule-details/` 內容。
-- 客製檔案（`extensions/bilingual-docs/`）不得被覆蓋。
+- 客製檔案（`.aidlc-rule-details/extensions/bilingual-docs/`）在覆蓋前要先備份、覆蓋後再放回（位置在 upstream 樹內，會被整批替換）。
+- `.aidlc-overrides/` 目錄**整個保留**，永不被 upstream 覆蓋（與 upstream 路徑分離）。新增的專案規則一律放在這裡，不要再加到 `.aidlc-rule-details/` 內。
 - 升級記錄寫入新 ADR。
 
 ---
@@ -100,6 +103,7 @@ This project adopts [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-w
    - `common/question-format-guide.md`
 3. Scan `.aidlc-rule-details/extensions/` and load **only** `*.opt-in.md` (lightweight). Full rule files are loaded after the user opts in.
 4. Extensions **without** an opt-in file (e.g. `bilingual-docs/`) are **always enforced** — load their full rule files immediately.
+5. **Finally**, load `.aidlc-overrides/**/*.md` (the project override layer). When an override conflicts with an upstream rule, **the override always wins**. See [`.aidlc-overrides/README.md`](.aidlc-overrides/README.md).
 
 **Three phases**:
 - 🔵 Inception — workspace detection, requirements analysis, user stories, application design
@@ -142,9 +146,11 @@ This repo is governed by `scripts/validate_repo_contract.py` (executed in CI):
 3. **Content validation**: before writing any file, validate Mermaid, ASCII diagrams, and special characters per `common/content-validation.md`.
 4. **Bilingual output**: every `aidlc-docs/**/*.md` must include both `## 中文版` and `## English Version`.
 5. **High-risk actions**: any production write / IaC apply / IAM change must come with a plan, impact analysis, and rollback strategy, and must pass through the human approval gate.
+6. **Branch naming**: before running `git checkout -b` / `git switch -c`, you **must** read [`.aidlc-overrides/branch-naming.md`](.aidlc-overrides/branch-naming.md) and produce a branch name matching `<uploader>/<type>/<slug>` (type ∈ {feat, fix, docs, chore, refactor, test}). All branches Danniel opens start with `danniel/`. If the user issues a conflicting instruction (e.g. dictates a non-compliant branch name), surface the conflict and ask for confirmation before proceeding.
 
 ### 7. Upgrading AIDLC
 
 - When upgrading, compare against `https://github.com/awslabs/aidlc-workflows/releases`, bump `.aidlc-rule-details/VERSION`, and re-copy the contents of `aws-aidlc-rule-details/`.
-- Custom files (`extensions/bilingual-docs/`) must not be overwritten.
+- Custom files inside the upstream tree (`.aidlc-rule-details/extensions/bilingual-docs/`) must be backed up before the copy and restored afterwards (they live inside the upstream tree and would otherwise be wiped by a wholesale replace).
+- The `.aidlc-overrides/` directory is **never** overwritten by upstream (it lives outside the upstream path). New project-specific rules must go here, not under `.aidlc-rule-details/`.
 - Record the upgrade in a new ADR.

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -45,6 +45,21 @@
 **Outcome**: PR2 待合併（branch `feat/aidlc-docs-migration`，stacked on PR1）。所有 cross-link 皆已更新並通過 validation。
 **Approver**: dannielchung@gmail.com
 
+#### 2026-05-09 — 新增 branch naming override（PR3）
+
+**User request (raw)**: 「未來分支名稱用 上傳人名字/feat/用途 這種命名規則來定義，請幫我調整流程，但不要動到aidlc框架的rule，額外疊加其他rule去蓋過」
+**Stage**: Inception → Process governance（override layer 新增）
+**Decisions**:
+- 新建 `.aidlc-overrides/` 目錄作為**專案 override 層**，不動 upstream `.aidlc-rule-details/`，避免未來 sync upstream 時受影響。
+- Override 載入順序固定為**最後一層**（CLAUDE.md 載入順序新增 step 5）；override 與 upstream 衝突時 override 永遠勝出。
+- 新增 `.aidlc-overrides/branch-naming.md` 規範 branch 格式 `<uploader>/<type>/<slug>`，type ∈ {feat, fix, docs, chore, refactor, test}；Danniel 一律以 `danniel/` 開頭。
+- CLAUDE.md 工作模式新增第 6 條：`git checkout -b` 之前必須先檢查 branch naming override。
+- CLAUDE.md 升級流程更新：明確 `.aidlc-overrides/` 永不被 upstream 覆蓋，新規則一律放這裡。
+- `validate_repo_contract.py` 把兩個 override 檔加進 REQUIRED_FILES 與 REQUIRED_TEXT，內含 enforcement 雙語與類型清單。
+- 採用本規則本身來示範：本次 PR 用 `danniel/feat/branch-naming-rule` 開分支。
+**Outcome**: PR3 待合併（branch `danniel/feat/branch-naming-rule`，stacked on PR2）。
+**Approver**: dannielchung@gmail.com
+
 ---
 
 ## English Version
@@ -87,4 +102,19 @@ Each entry uses the following structure:
 - `validate_repo_contract.py` `REQUIRED_FILES` / `REQUIRED_TEXT` now point at `aidlc-docs/inception/...`; the bilingual scan is fixed to `aidlc-docs/**/*.md`.
 - Removed all `docs/` references from README, CLAUDE.md, and bilingual-docs.md.
 **Outcome**: PR2 pending merge (branch `feat/aidlc-docs-migration`, stacked on PR1). All cross-links updated and validation passes.
+**Approver**: dannielchung@gmail.com
+
+#### 2026-05-09 — Add branch-naming override (PR3)
+
+**User request (raw)**: "未來分支名稱用 上傳人名字/feat/用途 這種命名規則來定義，請幫我調整流程，但不要動到aidlc框架的rule，額外疊加其他rule去蓋過"
+**Stage**: Inception → Process governance (introduce override layer)
+**Decisions**:
+- Create `.aidlc-overrides/` as the **project override layer** so we never have to modify upstream `.aidlc-rule-details/`; this keeps future upstream syncs safe.
+- Overrides are loaded **last** (CLAUDE.md rule-loading order gains step 5); on conflict between upstream and override, the override always wins.
+- Add `.aidlc-overrides/branch-naming.md` enforcing the format `<uploader>/<type>/<slug>` with type ∈ {feat, fix, docs, chore, refactor, test}; all Danniel branches must start with `danniel/`.
+- CLAUDE.md "Working Mode" gains item 6: check the branch-naming override before any `git checkout -b`.
+- CLAUDE.md "Upgrading AIDLC" updated to spell out that `.aidlc-overrides/` is never overwritten by upstream and that new project rules must go there.
+- `validate_repo_contract.py` now requires both override files in `REQUIRED_FILES` and `REQUIRED_TEXT`, including the bilingual sentinels and the allowed type list.
+- Self-applied: this PR itself uses the new format — branch `danniel/feat/branch-naming-rule`.
+**Outcome**: PR3 pending merge (branch `danniel/feat/branch-naming-rule`, stacked on PR2).
 **Approver**: dannielchung@gmail.com

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -32,6 +32,8 @@ REQUIRED_FILES = (
     "aidlc-docs/README.md",
     "aidlc-docs/aidlc-state.md",
     "aidlc-docs/audit.md",
+    ".aidlc-overrides/README.md",
+    ".aidlc-overrides/branch-naming.md",
 )
 
 REQUIRED_TEXT = {
@@ -127,6 +129,24 @@ REQUIRED_TEXT = {
     "aidlc-docs/README.md": (
         "AIDLC",
         "Bilingual",
+        "## 中文版",
+        "## English Version",
+    ),
+    ".aidlc-overrides/README.md": (
+        "Cloud-360 AIDLC Overrides",
+        "## 中文版",
+        "## English Version",
+    ),
+    ".aidlc-overrides/branch-naming.md": (
+        "Branch Naming Convention",
+        "<uploader>/<type>/<slug>",
+        "feat",
+        "fix",
+        "docs",
+        "chore",
+        "refactor",
+        "test",
+        "danniel",
         "## 中文版",
         "## English Version",
     ),


### PR DESCRIPTION
## Summary

Introduce \`.aidlc-overrides/\` as a project-specific override layer that sits **on top of** upstream AIDLC rules. The first override codifies the git branch naming convention so Claude Code (and any other AI agent) produces compliant names automatically.

> Per the user's directive, **no file under \`.aidlc-rule-details/\` is modified** — overrides live in a separate, upstream-safe directory.

> ⚠️ Base this PR on \`feat/aidlc-docs-migration\` (PR2). After PR1 and PR2 merge, retarget to \`main\`.

## Branch Naming Rule

\`<uploader>/<type>/<slug>\`

- \`<uploader>\`: lowercase contributor handle (Danniel uses \`danniel\`)
- \`<type>\` ∈ {\`feat\`, \`fix\`, \`docs\`, \`chore\`, \`refactor\`, \`test\`}
- \`<slug>\`: lowercase, hyphen-separated, 3–5 words

✅ Examples: \`danniel/feat/aidlc-docs-migration\`, \`danniel/fix/agent-routing-bug\`, \`danniel/docs/srs-update\`, \`danniel/chore/dependency-bump\`

## What's included

- \`.aidlc-overrides/README.md\` — bilingual; purpose of the layer, load order, precedence rules, authoring guide
- \`.aidlc-overrides/branch-naming.md\` — bilingual; the rule itself with examples, scope, enforcement notes
- \`CLAUDE.md\`:
  - rule-loading order gains step 5 (\`.aidlc-overrides/**/*.md\` loaded last; overrides win on conflict)
  - working mode gains item 6 (check branch-naming.md before any \`git checkout -b\`)
  - upgrading AIDLC clarifies \`.aidlc-overrides/\` is never overwritten by upstream
- \`scripts/validate_repo_contract.py\` — both override files in \`REQUIRED_FILES\` + \`REQUIRED_TEXT\`
- \`aidlc-docs/audit.md\` — bilingual PR3 audit entry

## Self-applied

This PR's own branch is \`danniel/feat/branch-naming-rule\`, which already follows the new convention.

## Test plan

- [x] \`python scripts/validate_repo_contract.py\` passes locally
- [ ] CI green
- [ ] \`git diff --name-only HEAD\` against PR2 base shows zero files under \`.aidlc-rule-details/\` (upstream untouched)
- [ ] Reviewer skim of \`.aidlc-overrides/branch-naming.md\` for the type whitelist + examples
- [ ] Confirm CLAUDE.md load order step 5 is clear about override precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)