### PR TITLE
feat: add .ailog/ folder and ai-logging override (PR4)

### DIFF
--- a/.aidlc-overrides/ai-logging.md
+++ b/.aidlc-overrides/ai-logging.md
@@ -1,0 +1,194 @@
+# AI Activity Logging Rule
+
+> Project override rule. Mandates that every AI turn touching the repository is logged in `.ailog/`.
+> 專案 override 規則。每一次 AI 動到本 repo 的對話 turn 都必須在 `.ailog/` 留下紀錄。
+
+## 中文版
+
+### 規範
+
+每一次 AI（Claude Code 與其他 AI agent）在本 repo 內**生成檔案、修改檔案、刪除檔案、執行 commit/push、開 PR**等任一動作後，**必須**在 `.ailog/<YYYY-MM-DD>.md` 追加一筆 turn entry。同一個 user 對話 turn 只寫一筆，無論該 turn 跑了多少 tool call。
+
+### 何時寫 log
+
+| 情境 | 是否必寫 |
+|---|---|
+| AI 用 Write / Edit / NotebookEdit 建檔或改檔 | ✅ 必寫 |
+| AI 用 Bash 執行 `git mv`、`git rm`、`mkdir`、`rm` 等修改 working tree 的指令 | ✅ 必寫 |
+| AI 執行 `git commit` / `git push` | ✅ 必寫 |
+| AI 用 `gh pr create` / `gh pr edit` / `gh pr merge` 等動到 GitHub 狀態 | ✅ 必寫 |
+| AI 純粹回答問題、查資料、跑 read-only `grep` / `git log` 沒動檔案 | ⏸ 可選（建議寫，量大時可省） |
+| 自動化 / 排程任務（scheduled cron job、loop） | ✅ 必寫，每跑一次寫一筆 |
+
+### 檔案格式
+
+- 路徑：`.ailog/<YYYY-MM-DD>.md`（依**當地時區**的日期；本專案預設 +0800）
+- 一個檔案 = 一天份所有 turn 的累積；append-only，不重排、不刪減過去條目
+- 每筆 turn entry 結構（H2/H3 階層）：
+
+```markdown
+## Turn N — HH:MM:SS +TZ
+
+**User request**: <verbatim user message，原文照抄；中英混雜可接受>
+**Branch**: <當前 git branch；若中途換 branch 也記下>
+**Files**:
+- A <path>      ← Added
+- M <path>      ← Modified
+- D <path>      ← Deleted
+- R <old> -> <new>  ← Renamed (git mv)
+**Tool calls (selected)**: <可選；列出有副作用的指令，例如 `gh pr create`、`git push`>
+**Summary**: <1–3 句話描述這個 turn 做了什麼以及 why；不需要逐行解說>
+**Commits (if any)**: <commit hash; 多個用逗號>
+**PRs (if any)**: <PR URL 或 #number>
+```
+
+- Turn 編號 N 在每天從 1 開始，依時間順序遞增
+- 時間使用 24h 格式，標明時區（例如 `14:35:12 +0800`）
+
+### 範例
+
+```markdown
+## Turn 1 — 16:48:20 +0800
+
+**User request**: 幫我在git增加一個folder叫做.ailog，另外加入一個規則檔...
+**Branch**: danniel/feat/ai-activity-logging
+**Files**:
+- A `.ailog/README.md`
+- A `.ailog/2026-05-09.md`
+- A `.aidlc-overrides/ai-logging.md`
+- M `CLAUDE.md`
+- M `scripts/validate_repo_contract.py`
+- M `aidlc-docs/audit.md`
+**Summary**: Established the AI activity logging mechanism: created `.ailog/` daily-log folder, authored the override rule, wired it into CLAUDE.md and the repo contract.
+**Commits**: cf28bfa, ...
+**PRs**: opendiamonds/cloud-360#13
+```
+
+### 隱私與資安
+
+- **禁止記錄秘密**：任何 token、API key、production credential 都絕對不可寫入 `.ailog/`。`scripts/validate_repo_contract.py` 的 `FORBIDDEN_CONTENT_PATTERNS` 會掃，違反等同 contract 違規。
+- 使用者貼進 prompt 的 raw 內容會被照抄到 `User request` 區塊；如果 user 在某 turn 提供了**敏感資料**（key、密碼、憑證），AI 必須在 log 中遮罩（例如用 `[REDACTED]`）並提醒 user。
+- `.ailog/` 隨 commit 進 git，會被 push 到 GitHub。請不要把不該公開的內容放進對話。
+- 不要把**其他專案 / 其他 session** 的內容混進來；`.ailog/` 只記錄本 repo 內的 AI 操作。
+
+### 與 `aidlc-docs/audit.md` 的差別
+
+| 對象 | 內容 | 粒度 |
+|---|---|---|
+| `aidlc-docs/audit.md` | AIDLC 階段事件（stage transitions、extension toggles、approvals、重大決策） | 粗：每個重要決策 1 筆 |
+| `.ailog/<date>.md` | 每一次 AI turn 的活動紀錄 | 細：每個 turn 1 筆 |
+
+兩者並存：audit.md 是 AIDLC workflow 的官方記錄；`.ailog/` 是底層全活動 log。當 turn 牽涉 AIDLC 決策（例如階段完成、extension 變更）時，**兩處都要寫**：細節進 `.ailog/`，摘要進 `audit.md`。
+
+### 與 upstream AIDLC rules 的關係
+
+upstream `awslabs/aidlc-workflows` 沒有對應規則，本規則為**純疊加**。`.aidlc-overrides/` 載入順序在 upstream 之後，故衝突時本規則勝出（目前無已知衝突）。
+
+### Enforcement
+
+- **AI agent**：在當前 turn 結束、回 user 訊息**之前**，先 append 該 turn 的 log entry；若已在跑 commit/push，把 commit hash / PR URL 補上。
+- **PR reviewer**：review 時檢查 `.ailog/<當天>.md` 是否有對應條目，且檔案清單是否與該 PR 的 git diff 一致。
+- **未來自動化**（可選，未強制）：CI 可加 step 比對「PR commits 觸碰的檔案」與「`.ailog/` 該日 entry 列出的 Files」一致性，不一致就 fail。本 override 暫不強制 CI 檢查，先以 review + AI 自律為主。
+
+### 套用範圍
+
+- ✅ 適用：所有 AI 在本 repo 內的對話 turn（透過 Claude Code、Cursor、其他 AI agent）。
+- ✅ 適用：自動化 cron / loop 任務每次執行。
+- ⏸ 不溯及：本規則建立**之前**的對話 turn 不必補登（`aidlc-docs/audit.md` 已記錄 PR1–PR3 的關鍵事件）。
+- ❌ 不適用：人類直接 commit、CI 自動 commit（dependabot 等）。
+
+---
+
+## English Version
+
+### Rule
+
+After every AI turn (Claude Code or any other AI agent) that **creates / modifies / deletes a file, runs a commit/push, or opens/edits a PR** in this repository, the AI **MUST** append a turn entry to `.ailog/<YYYY-MM-DD>.md`. Exactly one entry per user-visible turn, regardless of how many tool calls run inside that turn.
+
+### When to Log
+
+| Situation | Required? |
+|---|---|
+| AI uses Write / Edit / NotebookEdit to create or change files | ✅ Required |
+| AI uses Bash to run mutating commands such as `git mv`, `git rm`, `mkdir`, `rm` | ✅ Required |
+| AI runs `git commit` / `git push` | ✅ Required |
+| AI runs `gh pr create` / `gh pr edit` / `gh pr merge` or anything that mutates GitHub | ✅ Required |
+| AI only answers questions / queries data / runs read-only `grep` / `git log` without touching files | ⏸ Optional (recommended; may skip when noisy) |
+| Automated / scheduled tasks (cron, loop) | ✅ Required, one entry per run |
+
+### File Format
+
+- Path: `.ailog/<YYYY-MM-DD>.md` (date in **local timezone**; project default is `+0800`).
+- One file holds all turns of one calendar day; append-only — never reorder or delete past entries.
+- Each turn entry is structured:
+
+```markdown
+## Turn N — HH:MM:SS +TZ
+
+**User request**: <verbatim user message; mixed Chinese/English is fine>
+**Branch**: <current git branch; record any switch>
+**Files**:
+- A <path>      ← Added
+- M <path>      ← Modified
+- D <path>      ← Deleted
+- R <old> -> <new>  ← Renamed (git mv)
+**Tool calls (selected)**: <optional; list side-effecting commands such as `gh pr create`, `git push`>
+**Summary**: <1–3 sentences on what happened and why; no line-by-line walkthrough>
+**Commits (if any)**: <commit hash; comma-separated for multiple>
+**PRs (if any)**: <PR URL or #number>
+```
+
+- Turn numbers reset to 1 every day and increase chronologically.
+- Use 24-hour time and include the timezone (e.g. `14:35:12 +0800`).
+
+### Example
+
+```markdown
+## Turn 1 — 16:48:20 +0800
+
+**User request**: 幫我在git增加一個folder叫做.ailog，另外加入一個規則檔...
+**Branch**: danniel/feat/ai-activity-logging
+**Files**:
+- A `.ailog/README.md`
+- A `.ailog/2026-05-09.md`
+- A `.aidlc-overrides/ai-logging.md`
+- M `CLAUDE.md`
+- M `scripts/validate_repo_contract.py`
+- M `aidlc-docs/audit.md`
+**Summary**: Established the AI activity logging mechanism: created `.ailog/` daily-log folder, authored the override rule, wired it into CLAUDE.md and the repo contract.
+**Commits**: cf28bfa, ...
+**PRs**: opendiamonds/cloud-360#13
+```
+
+### Privacy and Security
+
+- **No secrets**: tokens, API keys, production credentials must never enter `.ailog/`. `scripts/validate_repo_contract.py`'s `FORBIDDEN_CONTENT_PATTERNS` will catch violations, which count as contract failures.
+- Raw user prompts are copied verbatim into the `User request` block. If a user pastes **sensitive data** (a key, a password, a credential), the AI must redact it (e.g. `[REDACTED]`) in the log and warn the user.
+- `.ailog/` is committed into git and pushed to GitHub. Do not paste anything you would not want public.
+- Do not mix in content from **other projects or sessions**; `.ailog/` only records AI activity inside this repo.
+
+### Difference from `aidlc-docs/audit.md`
+
+| Target | Content | Granularity |
+|---|---|---|
+| `aidlc-docs/audit.md` | AIDLC stage events (transitions, extension toggles, approvals, major decisions) | Coarse: one entry per major decision |
+| `.ailog/<date>.md` | Every AI turn's activity log | Fine: one entry per turn |
+
+Both coexist: `audit.md` is the official AIDLC workflow log; `.ailog/` is the underlying full-activity log. When a turn involves an AIDLC decision (stage completion, extension change), record **in both** — the detail goes to `.ailog/`, the summary to `audit.md`.
+
+### Relationship to Upstream AIDLC Rules
+
+Upstream `awslabs/aidlc-workflows` has no equivalent rule; this is a **pure addition**. `.aidlc-overrides/` is loaded after upstream, so on conflict this rule wins (no known conflict today).
+
+### Enforcement
+
+- **AI agents**: append the turn's log entry **before** sending the final response back to the user. If commit/push has already started, fill in commit hash / PR URL.
+- **PR reviewers**: during review, check that `.ailog/<that-day>.md` has the corresponding entry and that the file list matches the PR diff.
+- **Future automation (optional, not enforced)**: CI may add a step that compares the files touched by a PR's commits against the `Files` list in the `.ailog/` entry for that day; mismatches would fail the build. Not enforced yet — review + AI self-discipline first.
+
+### Scope
+
+- ✅ Applies to every AI turn in this repo (Claude Code, Cursor, other AI agents).
+- ✅ Applies to automated cron / loop runs (one entry per run).
+- ⏸ Not retroactive: turns **before** this rule was introduced are not back-filled (`aidlc-docs/audit.md` already records the key events for PR1–PR3).
+- ❌ Does not apply to direct human commits or automated CI commits (dependabot, etc.).

--- a/.ailog/2026-05-09.md
+++ b/.ailog/2026-05-09.md
@@ -1,0 +1,19 @@
+# AI Activity Log — 2026-05-09
+
+> Append-only. Format defined in `.aidlc-overrides/ai-logging.md`. Earlier same-day activity (PR1 / PR2 / PR3) is summarized in `aidlc-docs/audit.md` and is not back-filled here per the rule's "not retroactive" clause.
+
+## Turn 1 — 16:48:20 +0800
+
+**User request**: 幫我在git增加一個folder叫做.ailog，另外加入一個規則檔，每次AI生成的檔案跟回答都會記錄在.ailog，這個內容就幫我增加在裡面
+**Branch**: danniel/feat/ai-activity-logging（從 danniel/feat/branch-naming-rule 建立，stacked on PR3）
+**Files**:
+- A `.ailog/README.md`
+- A `.ailog/2026-05-09.md`
+- A `.aidlc-overrides/ai-logging.md`
+- M `CLAUDE.md`
+- M `scripts/validate_repo_contract.py`
+- M `aidlc-docs/audit.md`
+**Tool calls (selected)**: `git checkout -b danniel/feat/ai-activity-logging`, `mkdir -p .ailog`
+**Summary**: Established the AI activity logging mechanism per the user's directive: created `.ailog/` daily-log directory with bilingual README; authored `.aidlc-overrides/ai-logging.md` mandating per-turn entries with file deltas / branch / commit hash / PR; wired the rule into CLAUDE.md "Working Mode" item 7 and into `scripts/validate_repo_contract.py` REQUIRED_FILES + REQUIRED_TEXT; appended PR4 entry to `aidlc-docs/audit.md`. Self-applied: this very entry is the first log produced under the new rule.
+**Commits**: <pending>
+**PRs**: <pending — will be opened after CI green on PR3>

--- a/.ailog/README.md
+++ b/.ailog/README.md
@@ -1,0 +1,76 @@
+# `.ailog/` — AI Activity Log
+
+> Append-only per-turn activity log produced by AI agents working in this repository.
+> AI agent 在本 repo 動到檔案時逐 turn 留下的 append-only 活動紀錄。
+
+## 中文版
+
+### 目的
+
+`.ailog/` 是 Cloud-360 的 AI 操作底層紀錄。每一次 AI（Claude Code 與其他 AI agent）建檔、改檔、刪檔、commit / push 或開 PR，都會在此目錄當天的 markdown 檔追加一筆 turn entry。
+
+詳細規則由 [`.aidlc-overrides/ai-logging.md`](../.aidlc-overrides/ai-logging.md) 訂定。
+
+### 結構
+
+- `<YYYY-MM-DD>.md` — 當天所有 turn 的累積，append-only。
+- 每天一份檔案；第一筆 turn N=1，依時間順序往下加。
+
+```text
+.ailog/
+├── README.md        ← 本檔（雙語說明）
+├── 2026-05-09.md
+├── 2026-05-10.md
+└── ...
+```
+
+### 與 `aidlc-docs/audit.md` 的關係
+
+- `aidlc-docs/audit.md` = AIDLC 階段官方稽核（粗粒度，每個重大決策 1 筆）。
+- `.ailog/` = 全活動底層 log（細粒度，每個 turn 1 筆）。
+- 兩者並存：當 turn 牽涉 AIDLC 階段事件時，兩處同時寫，`.ailog/` 寫細節，`audit.md` 寫摘要。
+
+### 重要原則
+
+1. **Append-only**：禁止重排、刪減、編輯歷史條目。發現紀錄錯誤時，加新條目修正，原條目保留。
+2. **不寫秘密**：token / API key / production credential 一律不可進 `.ailog/`，`scripts/validate_repo_contract.py` 會掃。
+3. **隨 commit 進 git**：每個 PR 對應的 turn entry 應與該 PR 的 commits 一起進 git。
+4. **不溯及**：本機制建立前的 AI 活動不必補登；早期事件已記錄在 `aidlc-docs/audit.md`。
+5. **語言**：log entry 不強制雙語（操作 log 偏機讀），但 README 與 override rule 雙語。
+
+---
+
+## English Version
+
+### Purpose
+
+`.ailog/` is Cloud-360's underlying log of AI activity. Whenever an AI (Claude Code or any other AI agent) creates / modifies / deletes a file, runs a commit/push, or opens a PR, it appends a turn entry to that day's markdown file in this directory.
+
+The full rule is defined in [`.aidlc-overrides/ai-logging.md`](../.aidlc-overrides/ai-logging.md).
+
+### Structure
+
+- `<YYYY-MM-DD>.md` — accumulates every turn for that day, append-only.
+- One file per day; the first turn is `N=1`, subsequent entries follow chronologically.
+
+```text
+.ailog/
+├── README.md        ← this file (bilingual)
+├── 2026-05-09.md
+├── 2026-05-10.md
+└── ...
+```
+
+### Relationship to `aidlc-docs/audit.md`
+
+- `aidlc-docs/audit.md` = AIDLC stage audit log (coarse — one entry per major decision).
+- `.ailog/` = full underlying activity log (fine — one entry per turn).
+- They coexist: when a turn touches an AIDLC stage event, write to both — the detail goes to `.ailog/`, the summary to `audit.md`.
+
+### Key Principles
+
+1. **Append-only**: do not reorder, delete, or edit past entries. If you find a mistake, add a new entry that corrects it; keep the original.
+2. **No secrets**: tokens / API keys / production credentials must never enter `.ailog/`. `scripts/validate_repo_contract.py` will catch violations.
+3. **Committed with git**: turn entries belonging to a PR should be committed alongside that PR's commits.
+4. **Not retroactive**: AI activity before this mechanism was introduced is not back-filled; earlier events are already in `aidlc-docs/audit.md`.
+5. **Language**: log entries are not required to be bilingual (machine-readable operational log), but the README and the override rule are bilingual.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Cloud-360 是 AI-native multi-cloud architecture & operations platform，支援 
 4. **雙語產出**：所有 `aidlc-docs/**/*.md` 一定要同時有 `## 中文版` 與 `## English Version`。
 5. **High-risk action**：任何 production write / IaC apply / IAM 變更必須先給 plan + impact + rollback，並通過 human approval gate。
 6. **Branch naming**：在 `git checkout -b` / `git switch -c` 之前，**必須**先讀 [`.aidlc-overrides/branch-naming.md`](.aidlc-overrides/branch-naming.md) 並產出符合 `<uploader>/<type>/<slug>` 的 branch 名稱（type ∈ {feat, fix, docs, chore, refactor, test}）。Danniel 開的 branch 一律以 `danniel/` 開頭。如果使用者下達衝突指令（例如直接給一個不合規的 branch 名稱），先提醒衝突並請使用者確認。
+7. **AI activity logging**：每一次動到檔案 / commit / push / 開 PR 的 turn，回 user 訊息**之前**必須在 `.ailog/<YYYY-MM-DD>.md`（local timezone）追加一筆 turn entry。完整格式與適用範圍見 [`.aidlc-overrides/ai-logging.md`](.aidlc-overrides/ai-logging.md)。Read-only turn 可省。`.ailog/` append-only，不重排、不改舊條目。
 
 ### 7. AIDLC 升級
 
@@ -147,6 +148,7 @@ This repo is governed by `scripts/validate_repo_contract.py` (executed in CI):
 4. **Bilingual output**: every `aidlc-docs/**/*.md` must include both `## 中文版` and `## English Version`.
 5. **High-risk actions**: any production write / IaC apply / IAM change must come with a plan, impact analysis, and rollback strategy, and must pass through the human approval gate.
 6. **Branch naming**: before running `git checkout -b` / `git switch -c`, you **must** read [`.aidlc-overrides/branch-naming.md`](.aidlc-overrides/branch-naming.md) and produce a branch name matching `<uploader>/<type>/<slug>` (type ∈ {feat, fix, docs, chore, refactor, test}). All branches Danniel opens start with `danniel/`. If the user issues a conflicting instruction (e.g. dictates a non-compliant branch name), surface the conflict and ask for confirmation before proceeding.
+7. **AI activity logging**: in any turn that mutates files / commits / pushes / opens a PR, you **must** append a turn entry to `.ailog/<YYYY-MM-DD>.md` (local timezone) **before** sending the final response to the user. Full format and scope: [`.aidlc-overrides/ai-logging.md`](.aidlc-overrides/ai-logging.md). Read-only turns may skip. `.ailog/` is append-only — never reorder or edit past entries.
 
 ### 7. Upgrading AIDLC
 

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -60,6 +60,21 @@
 **Outcome**: PR3 待合併（branch `danniel/feat/branch-naming-rule`，stacked on PR2）。
 **Approver**: dannielchung@gmail.com
 
+#### 2026-05-09 — 新增 `.ailog/` 與 ai-logging override（PR4）
+
+**User request (raw)**: 「幫我在git增加一個folder叫做.ailog，另外加入一個規則檔，每次AI生成的檔案跟回答都會記錄在.ailog，這個內容就幫我增加在裡面」
+**Stage**: Inception → Process governance（新增 AI 活動底層 log 機制）
+**Decisions**:
+- 新增 `.ailog/` 目錄作為**逐 turn AI 活動底層 log**，與 `aidlc-docs/audit.md`（粗粒度 AIDLC 階段稽核）形成上下兩層。
+- 新規則寫在 `.aidlc-overrides/ai-logging.md`（不動 upstream），格式為 `.ailog/<YYYY-MM-DD>.md`，每天一檔、append-only。
+- Turn entry 結構：User request、Branch、Files（A/M/D/R）、Tool calls、Summary、Commits、PRs。
+- 不溯及：本機制建立前的 turn 不必補登；PR1–PR3 的關鍵事件已記錄於本檔。
+- CLAUDE.md 工作模式新增第 7 條：mutating turn 在回 user 前必須先寫 `.ailog/` entry。
+- `validate_repo_contract.py` 新增 `.aidlc-overrides/ai-logging.md`、`.ailog/README.md` 為 REQUIRED_FILES，並驗 REQUIRED_TEXT 雙語與關鍵字。
+- 自我示範：本 PR 自身的 turn 已寫入 `.ailog/2026-05-09.md`。
+**Outcome**: PR4 待合併（branch `danniel/feat/ai-activity-logging`，stacked on PR3）。
+**Approver**: dannielchung@gmail.com
+
 ---
 
 ## English Version
@@ -117,4 +132,19 @@ Each entry uses the following structure:
 - `validate_repo_contract.py` now requires both override files in `REQUIRED_FILES` and `REQUIRED_TEXT`, including the bilingual sentinels and the allowed type list.
 - Self-applied: this PR itself uses the new format — branch `danniel/feat/branch-naming-rule`.
 **Outcome**: PR3 pending merge (branch `danniel/feat/branch-naming-rule`, stacked on PR2).
+**Approver**: dannielchung@gmail.com
+
+#### 2026-05-09 — Add `.ailog/` and ai-logging override (PR4)
+
+**User request (raw)**: "幫我在git增加一個folder叫做.ailog，另外加入一個規則檔，每次AI生成的檔案跟回答都會記錄在.ailog，這個內容就幫我增加在裡面"
+**Stage**: Inception → Process governance (introduce a per-turn AI activity log)
+**Decisions**:
+- Create `.ailog/` as the **per-turn AI activity log**, layered below `aidlc-docs/audit.md` (which remains the coarse AIDLC stage audit).
+- The new rule lives in `.aidlc-overrides/ai-logging.md` (upstream untouched). Format: `.ailog/<YYYY-MM-DD>.md`, one file per day, append-only.
+- Turn entry structure: User request / Branch / Files (A/M/D/R) / Tool calls / Summary / Commits / PRs.
+- Not retroactive: turns before this rule are not back-filled; PR1–PR3 key events already exist in this file.
+- CLAUDE.md "Working Mode" gains item 7: mutating turns must append a `.ailog/` entry before sending the final response.
+- `validate_repo_contract.py` adds `.aidlc-overrides/ai-logging.md` and `.ailog/README.md` to `REQUIRED_FILES`, with bilingual sentinels and key terms in `REQUIRED_TEXT`.
+- Self-applied: this PR's own turn was logged to `.ailog/2026-05-09.md`.
+**Outcome**: PR4 pending merge (branch `danniel/feat/ai-activity-logging`, stacked on PR3).
 **Approver**: dannielchung@gmail.com

--- a/scripts/validate_repo_contract.py
+++ b/scripts/validate_repo_contract.py
@@ -34,6 +34,8 @@ REQUIRED_FILES = (
     "aidlc-docs/audit.md",
     ".aidlc-overrides/README.md",
     ".aidlc-overrides/branch-naming.md",
+    ".aidlc-overrides/ai-logging.md",
+    ".ailog/README.md",
 )
 
 REQUIRED_TEXT = {
@@ -147,6 +149,22 @@ REQUIRED_TEXT = {
         "refactor",
         "test",
         "danniel",
+        "## 中文版",
+        "## English Version",
+    ),
+    ".aidlc-overrides/ai-logging.md": (
+        "AI Activity Logging Rule",
+        ".ailog/",
+        "<YYYY-MM-DD>.md",
+        "append-only",
+        "No secrets",
+        "## 中文版",
+        "## English Version",
+    ),
+    ".ailog/README.md": (
+        "AI Activity Log",
+        "append-only",
+        ".aidlc-overrides/ai-logging.md",
         "## 中文版",
         "## English Version",
     ),


### PR DESCRIPTION
## Summary

Introduce a per-turn AI activity log so every file change, commit, push, and PR action made by an AI agent is recorded under `.ailog/`. This sits **below** `aidlc-docs/audit.md` (which remains the coarse AIDLC stage audit) and gives reviewers a fine-grained activity trail.

Following the project override pattern (PR3), the rule lives in `.aidlc-overrides/ai-logging.md` so upstream `.aidlc-rule-details/` is **not** modified.

> ⚠️ Base: `danniel/feat/branch-naming-rule` (PR3). After PR1–PR3 merge, retarget to `main`.

## Logging contract

- **Path**: `.ailog/<YYYY-MM-DD>.md` (one file per day, append-only)
- **Trigger**: every AI turn that mutates files / commits / pushes / opens or edits a PR
- **Skip**: pure read-only Q&A turns (optional — recommended when noisy)
- **Entry shape**: User request (verbatim) · Branch · Files (A/M/D/R) · Selected tool calls · Summary · Commit hashes · PR URLs
- **Privacy**: secrets are forbidden in `.ailog/` (already enforced by `validate_repo_contract.py` `FORBIDDEN_CONTENT_PATTERNS`); user must redact accidental paste-ins
- **Not retroactive**: PR1–PR3 turns are not back-filled (already in `aidlc-docs/audit.md`)

## What's included

- `.ailog/README.md` — bilingual; purpose, structure, privacy / append-only principles
- `.ailog/2026-05-09.md` — first turn entry (this PR), demonstrating the format
- `.aidlc-overrides/ai-logging.md` — bilingual; the rule itself with full format spec, scope, enforcement notes, and difference from `audit.md`
- `CLAUDE.md` — Working Mode gains item 7 (mutating turns must append `.ailog/` entry before final response)
- `scripts/validate_repo_contract.py` — `REQUIRED_FILES` gains the rule + README; `REQUIRED_TEXT` verifies bilingual sentinels and key terms (`append-only`, `<YYYY-MM-DD>.md`, etc.)
- `aidlc-docs/audit.md` — bilingual PR4 audit entry

## Self-applied

This PR's own activity is the first entry in `.ailog/2026-05-09.md` (Turn 1 — 16:48:20 +0800).

## Test plan

- [x] \`python scripts/validate_repo_contract.py\` passes locally
- [ ] CI green
- [ ] \`git diff --name-only HEAD\` against PR3 base shows zero files under \`.aidlc-rule-details/\` (upstream untouched)
- [ ] Reviewer sanity-check on `.ailog/2026-05-09.md` Turn 1 (does the file list match this PR's diff?)
- [ ] Confirm CLAUDE.md item 7 is clear that the entry is appended **before** the final response

🤖 Generated with [Claude Code](https://claude.com/claude-code)