### PR TITLE
chore: log Turn 3 — stale stacked branches deleted

### DIFF
--- a/.ailog/2026-05-09.md
+++ b/.ailog/2026-05-09.md
@@ -43,3 +43,15 @@
 **Summary**: Stale stacked branches removed from origin after both safety checks passed (Check1 = `.ailog/`, `.aidlc-overrides/`, `aidlc-docs/inception/` exist on main; Check2 = all 4 expected commits `1c59633` `cf28bfa` `3f639cf` `f3fbd22` reachable from main, confirming non-squash merge). Local branches also deleted; tracking refs pruned. Backup SHAs remain in `/tmp/cloud-360-cleanup-watcher.sh` for restoration if needed.
 **Commits**: <pending>
 **PRs**: <pending — small chore PR for this log entry>
+
+## Turn 4 — 17:21:01 +0800
+
+**User request**: merge PR #15 並刪掉那個 branch
+**Context**: User authorized merging the chore PR (#15) and deleting `danniel/feat/ai-activity-logging` (the PR4-head branch flagged earlier). Adding Turn 4 to the same branch (PR #15's head) so it ships in the same merge — avoids a recursive Turn-N PR for every chore action.
+**Branch**: danniel/chore/log-branch-cleanup（同 PR #15 head；新 commit 會被同一個 PR 帶進 main）
+**Files**:
+- M `.ailog/2026-05-09.md`（追加 Turn 4 entry）
+**Tool calls (selected, planned)**: `git commit`, `git push origin danniel/chore/log-branch-cleanup`, watcher 完成: `gh pr merge 15 --merge --delete-branch`, `git push origin --delete danniel/feat/ai-activity-logging`
+**Summary**: Append Turn 4 to the active chore branch, push, then hand off to a background watcher that waits for PR #15's CI green, merges it (`--merge --delete-branch` cleans up the chore head branch automatically), and finally deletes `danniel/feat/ai-activity-logging` from origin once merge settles. Net result: main gets Turn 3 + Turn 4 entries; both stale danniel/* branches removed in one turn.
+**Commits**: <pending>
+**PRs**: PR #15 (this branch) → main

--- a/.ailog/2026-05-09.md
+++ b/.ailog/2026-05-09.md
@@ -31,3 +31,15 @@
 **Summary**: Open a remediation PR from `danniel/feat/ai-activity-logging` (which already stacks PR2 + PR3 + PR4 commits on top of main's PR1) directly to `main`. One PR, one merge — lands all three missing PRs in a single shot, preserving each commit's history. Also self-corrected an earlier append-only violation: reverted an inadvertent edit to Turn 1's `<pending>` fields and moved the back-fill info to this Note section instead.
 **Commits**: <pending>
 **PRs**: <pending — fix PR opened to main>
+
+## Turn 3 — 17:16:40 +0800
+
+**User request**: 我合併了，可以刪了
+**Context**: PR #14 (fix) merged to main at 2026-05-09T09:14:26Z (commit `8860b9d`). User confirmed merge and authorized cleanup of the 3 stacked branches (PR #11/#12/#13 heads). The PR4-head branch `danniel/feat/ai-activity-logging` was earlier flagged separately and remains pending user decision; this turn does NOT delete it.
+**Branch**: danniel/chore/log-branch-cleanup（從 main 新開，name follows `<uploader>/<type>/<slug>` per branch-naming override; type=chore, slug=log-branch-cleanup is 3 hyphenated words）
+**Files**:
+- M `.ailog/2026-05-09.md`（追加本 Turn 3 entry）
+**Tool calls (selected)**: previously-launched background watcher `bxpv1f2th` did `git push origin --delete feat/aidlc-framework-rules`, `git push origin --delete feat/aidlc-docs-migration`, `git push origin --delete danniel/feat/branch-naming-rule`; foreground `git checkout main`, `git pull`, `git remote prune origin`, local `git branch -D` x3
+**Summary**: Stale stacked branches removed from origin after both safety checks passed (Check1 = `.ailog/`, `.aidlc-overrides/`, `aidlc-docs/inception/` exist on main; Check2 = all 4 expected commits `1c59633` `cf28bfa` `3f639cf` `f3fbd22` reachable from main, confirming non-squash merge). Local branches also deleted; tracking refs pruned. Backup SHAs remain in `/tmp/cloud-360-cleanup-watcher.sh` for restoration if needed.
+**Commits**: <pending>
+**PRs**: <pending — small chore PR for this log entry>


### PR DESCRIPTION
## Summary

Per \`.aidlc-overrides/ai-logging.md\`, every AI turn that mutates GitHub state must append a turn entry to \`.ailog/<YYYY-MM-DD>.md\`. The background watcher (\`bxpv1f2th\`) deleted three stale stacked branches on origin after PR #14 landed; this PR appends the corresponding **Turn 3** entry.

## Branches removed (from origin)

- \`feat/aidlc-framework-rules\`
- \`feat/aidlc-docs-migration\`
- \`danniel/feat/branch-naming-rule\`

Backup SHAs are preserved in the watcher script (\`/tmp/cloud-360-cleanup-watcher.sh\`) and in the Turn 3 entry's notes; any branch can be restored with \`git push origin <sha>:refs/heads/<branch>\`.

## Safety checks (both passed before deletion)

- **Check 1 — content arrived on main**: \`.ailog/README.md\`, \`.aidlc-overrides/README.md\`, \`aidlc-docs/inception/requirements/cloud-360-srs.md\` all present.
- **Check 2 — original commit hashes reachable**: \`1c59633\` (PR2), \`cf28bfa\` (PR3), \`3f639cf\` (PR4), \`f3fbd22\` (Turn 2 audit) all reachable from main, confirming the merge was **not** a squash.

## Out of scope

- The PR4-head branch \`danniel/feat/ai-activity-logging\` is still on origin. It was flagged separately and remains pending user decision (no authorization to delete yet).

## Future improvement

If pure-cleanup turns become noisy (each requiring a tiny PR), we may extend \`.aidlc-overrides/ai-logging.md\` with a "deferred logging" carve-out that lets cleanup entries batch into the next substantive PR. Not done in this PR — kept the rule strict for now.

## Test plan

- [x] \`python scripts/validate_repo_contract.py\` passes locally
- [ ] CI green
- [ ] After merge, branch list on GitHub shows only \`main\` + the legitimately-open \`danniel/feat/ai-activity-logging\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)