### PR TITLE
docs: add wave-based development plan HTML (PR #18)

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -146,6 +146,20 @@
 **Outcome**: PR #18 待合併到 main。
 **Approver**: dannielchung@gmail.com
 
+#### 2026-05-10 — PR #18 補強：HTML 改 kanban + 開 GitHub Project
+
+**User request (raw)**: 「剛剛的PR請調整HTML，輸出的HTML以看板模式呈現，或者輸出到Project看板功能裡」（決議：兩個都做、欄位依 Wave）
+**Stage**: Inception → Workflow Planning（視覺化 + 線上 live 看板）
+**Decisions**:
+- 在 PR #18 同一 branch 補 commit：HTML 把 §2 從堆疊式 wave cards 改為 4 欄 kanban board（W0/W1/W2/W3），每個 user story 為卡片，含 ID、title、pillar tag、deps；保留相依圖、story table、pillar 細節等其他段落。
+- 新增 GitHub Project: **Cloud-360 Development Plan**（owner=Dannielchung，public，URL: <https://github.com/users/Dannielchung/projects/1>）。Org-level project 因 `opendiamonds` 是 user account 而非 org，無法在該 owner 下建 Project，故掛 Dannielchung 個人；可連結 opendiamonds/cloud-360 的 issues / PRs。
+- Project 自訂 3 個欄位：Wave（W0–W3 single-select）、Pillar（A–I single-select）、Story ID（text）。內建 Status 欄位保留。
+- 寫入 26 個 draft items（每條 user story 一個），自動填上 Wave / Pillar / Story ID。
+- HTML header 加入 "View on GitHub Project" 按鈕；plans/README.md 表格新增 live project 列。
+- Auth：因 `gh` token 缺 `project` scope，請 user 手動跑 `gh auth refresh -h github.com -s project` 後才得以建 Project。
+**Outcome**: PR #18 取得新 commit；Project 公開可看。
+**Approver**: dannielchung@gmail.com
+
 ---
 
 ## English Version
@@ -289,4 +303,18 @@ Each entry uses the following structure:
 - No changes to SRS or user-stories source files; this plan is a derived artifact.
 - Plan does not add or remove SRS pillars, so no new ADR is required; if future wave breakdowns change scope, a new ADR will be opened.
 **Outcome**: PR #18 pending merge to main.
+**Approver**: dannielchung@gmail.com
+
+#### 2026-05-10 — PR #18 follow-up: HTML kanban + GitHub Project
+
+**User request (raw)**: "剛剛的PR請調整HTML，輸出的HTML以看板模式呈現，或者輸出到Project看板功能裡" (decision: both, columns by Wave)
+**Stage**: Inception → Workflow Planning (visualization + live online board)
+**Decisions**:
+- Added a follow-up commit to the same PR #18 branch: HTML §2 switched from stacked wave cards to a 4-column kanban board (W0/W1/W2/W3); every user story is a card showing ID, title, pillar tag, and dependencies. Other sections (dependency graph, story table, pillar details) preserved.
+- Created GitHub Project **Cloud-360 Development Plan** (owner=Dannielchung, public, URL: <https://github.com/users/Dannielchung/projects/1>). Project lives under Dannielchung because `opendiamonds` is a user account (not an organization), so we cannot create projects under that owner; the project still links to issues / PRs in opendiamonds/cloud-360.
+- Project has three custom fields: Wave (single-select W0–W3), Pillar (single-select A–I), Story ID (text). Built-in Status field retained.
+- Seeded with 26 draft items (one per user story) with Wave / Pillar / Story ID populated.
+- HTML header gains a "View on GitHub Project" button; `plans/README.md` table lists the live project row.
+- Auth note: the `gh` CLI was missing the `project` scope, so the user manually ran `gh auth refresh -h github.com -s project` before project creation could proceed.
+**Outcome**: PR #18 receives a new commit; the GitHub Project is public.
 **Approver**: dannielchung@gmail.com

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -133,6 +133,19 @@
 **Outcome**: PR #17 待合併到 main。
 **Approver**: dannielchung@gmail.com
 
+#### 2026-05-10 — 新增 wave-based 開發計劃 HTML（PR #18）
+
+**User request (raw)**: 「幫我把SRS 裡 9 個 pillar、26 條 user stories 整理成一個開發計劃，輸出成一個HTML給我」
+**Stage**: Inception → Workflow Planning（pillar 級 wave 規劃）
+**Decisions**:
+- 新增 `aidlc-docs/inception/plans/development-plan.html`：依 SRS pillars 與 user-stories 整理，分 4 個 wave（W0 Foundation、W1 Core Differentiators、W2 FinOps/Ops/Mobile、W3 Extensions），含相依圖（Mermaid）、story table、pillar 細節、NFR、已知風險、下一步建議。
+- 採單檔 HTML（inline CSS、Mermaid via CDN），可直接 `open` 瀏覽，亦可離線閱讀（Mermaid 不可用時純文字仍可看）。
+- 新增 `aidlc-docs/inception/plans/README.md`（雙語），說明 plans/ 目錄角色與其他 inception 子目錄的關係。
+- 不對 SRS / user-stories 原檔做改動；本計劃為衍生 artifact。
+- 此計劃尚未對 SRS scope 加 / 減 pillar，所以不需要新 ADR；後續 wave 拆細時若改變 scope 再開 ADR。
+**Outcome**: PR #18 待合併到 main。
+**Approver**: dannielchung@gmail.com
+
 ---
 
 ## English Version
@@ -263,4 +276,17 @@ Each entry uses the following structure:
 - `scripts/validate_repo_contract.py`: `REQUIRED_FILES` drops `.ailog/README.md` and `.aidlc-overrides/ai-logging.md`, adds `.aidlc-overrides/decisions-log.md` and `aidlc-docs/decisions-log.md`; `REQUIRED_TEXT` keys swapped accordingly.
 - Self-applied: the decision itself ("remove ai-logging, adopt on-demand decisions-log") is the first entry in `aidlc-docs/decisions-log.md`.
 **Outcome**: PR #17 pending merge to main.
+**Approver**: dannielchung@gmail.com
+
+#### 2026-05-10 — Add wave-based development plan HTML (PR #18)
+
+**User request (raw)**: "幫我把SRS 裡 9 個 pillar、26 條 user stories 整理成一個開發計劃，輸出成一個HTML給我"
+**Stage**: Inception → Workflow Planning (pillar-level wave plan)
+**Decisions**:
+- Added `aidlc-docs/inception/plans/development-plan.html`: SRS pillars and user stories organized into four waves (W0 Foundation, W1 Core Differentiators, W2 FinOps/Ops/Mobile, W3 Extensions). Contains a dependency graph (Mermaid), full story table, pillar details, NFRs, known risks, and recommended next steps.
+- Single-file HTML (inline CSS, Mermaid via CDN) — can be opened directly in a browser and remains readable offline (text-only fallback if Mermaid is unavailable).
+- Added `aidlc-docs/inception/plans/README.md` (bilingual) describing the role of `plans/` and its relationship to other inception subdirectories.
+- No changes to SRS or user-stories source files; this plan is a derived artifact.
+- Plan does not add or remove SRS pillars, so no new ADR is required; if future wave breakdowns change scope, a new ADR will be opened.
+**Outcome**: PR #18 pending merge to main.
 **Approver**: dannielchung@gmail.com

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -160,6 +160,20 @@
 **Outcome**: PR #18 取得新 commit；Project 公開可看。
 **Approver**: dannielchung@gmail.com
 
+#### 2026-05-10 — PR #18 修正：改用 opendiamonds/projects/16 + 計劃內容繁中化
+
+**User request (raw)**: 「https://github.com/users/opendiamonds/projects/16 這才是Github Project的位置，不要額外另開一個，另外計劃內容要用繁體中文！」
+**Stage**: Inception → Workflow Planning（修正 Project 位置 + 完整翻 Traditional Chinese）
+**Decisions**:
+- 把 26 個 items 加到既有 `opendiamonds/projects/16`（標題前綴 `[Cloud-360]` 區分另外 4 個現有 items），並在該 project 上補建 3 個自訂欄位 Wave / Pillar / Story ID（皆繁中選項）；Status 沿用內建欄位，預設值設為 Backlog。
+- 刪除上一輪誤建的 Dannielchung project 1（`gh project delete 1`），避免有兩個來源的混淆。
+- HTML 內容繁中化：story titles、kanban 卡片、story table 標頭與內容、9 個 pillar block 標題、stat 卡片 label、相依圖節點、NFR/Risks/Next Steps 段落標題、footer。技術名詞（Mermaid、draw.io、IaC、MCP、OPA、Sentinel、Terraform、Spot/Preemptible 等）保留英文。
+- HTML header CTA 與 footer 連結指向 `https://github.com/users/opendiamonds/projects/16`。
+- README 更新為新位置、文字繁中化（指出 26 items 標題前綴 `[Cloud-360]`、自訂欄位、Status 流程）。
+- 不動 SRS / user stories 原檔（仍英中混合）；只改開發計劃 artifact。
+**Outcome**: PR #18 第 3 個 commit；live kanban 在 opendiamonds/projects/16；HTML 完全繁中。
+**Approver**: dannielchung@gmail.com
+
 ---
 
 ## English Version
@@ -317,4 +331,18 @@ Each entry uses the following structure:
 - HTML header gains a "View on GitHub Project" button; `plans/README.md` table lists the live project row.
 - Auth note: the `gh` CLI was missing the `project` scope, so the user manually ran `gh auth refresh -h github.com -s project` before project creation could proceed.
 **Outcome**: PR #18 receives a new commit; the GitHub Project is public.
+**Approver**: dannielchung@gmail.com
+
+#### 2026-05-10 — PR #18 fix-up: use opendiamonds/projects/16 + Traditional Chinese plan content
+
+**User request (raw)**: "https://github.com/users/opendiamonds/projects/16 這才是Github Project的位置，不要額外另開一個，另外計劃內容要用繁體中文！"
+**Stage**: Inception → Workflow Planning (correct project location + full Traditional Chinese rendering)
+**Decisions**:
+- Added the 26 items into the **existing** `opendiamonds/projects/16` (titles prefixed `[Cloud-360]` to distinguish from the 4 unrelated items already there) and created three custom fields on that project: Wave / Pillar / Story ID (Traditional Chinese option labels). Status reuses the built-in field, defaulting to Backlog for new items.
+- Deleted the misplaced Dannielchung project 1 created earlier (`gh project delete 1`) to avoid two sources of truth.
+- Localized the HTML to Traditional Chinese: story titles, kanban cards, story-table headers and rows, 9 pillar block titles, stat-card labels, dependency-graph node text, section headers for NFR/Risks/Next Steps, and the footer. Technical proper nouns (Mermaid, draw.io, IaC, MCP, OPA, Sentinel, Terraform, Spot/Preemptible, etc.) remain in English.
+- HTML header CTA and footer link now point to `https://github.com/users/opendiamonds/projects/16`.
+- README updated to the new project location and rephrased in Traditional Chinese (noting the `[Cloud-360]` prefix, custom fields, and Status flow).
+- Source SRS / user-stories files are not modified (still mixed English/Chinese); only the planning artifact is localized.
+**Outcome**: PR #18 third commit; live kanban now lives at opendiamonds/projects/16; HTML fully in Traditional Chinese.
 **Approver**: dannielchung@gmail.com

--- a/aidlc-docs/inception/plans/README.md
+++ b/aidlc-docs/inception/plans/README.md
@@ -11,7 +11,8 @@
 
 | 檔案 | 說明 |
 |---|---|
-| [`development-plan.html`](development-plan.html) | 9 pillar / 26 user story 的 wave-based 開發計劃；含相依圖、story table、pillar 細節、NFR 與風險。**建議用瀏覽器開啟**：`open aidlc-docs/inception/plans/development-plan.html`。 |
+| [`development-plan.html`](development-plan.html) | 9 pillar / 26 user story 的 wave-based 開發計劃；含 Kanban 看板、相依圖、story table、pillar 細節、NFR 與風險。**建議用瀏覽器開啟**：`open aidlc-docs/inception/plans/development-plan.html`。 |
+| [GitHub Project (live)](https://github.com/users/Dannielchung/projects/1) | live kanban，26 個 draft items，欄位：Wave / Pillar / Story ID。可直接拖卡片改 status |
 
 ### 與其他 inception 子目錄的關係
 
@@ -37,7 +38,8 @@
 
 | File | Purpose |
 |---|---|
-| [`development-plan.html`](development-plan.html) | Wave-based development plan covering all 9 pillars and 26 user stories; includes dependency graph, story table, pillar details, NFRs, and known risks. **Open in a browser**: `open aidlc-docs/inception/plans/development-plan.html`. |
+| [`development-plan.html`](development-plan.html) | Wave-based development plan covering all 9 pillars and 26 user stories; includes Kanban board, dependency graph, story table, pillar details, NFRs, and known risks. **Open in a browser**: `open aidlc-docs/inception/plans/development-plan.html`. |
+| [GitHub Project (live)](https://github.com/users/Dannielchung/projects/1) | Live kanban with 26 draft items; custom fields Wave / Pillar / Story ID. Drag cards to update status. |
 
 ### Relationship to other inception subdirectories
 

--- a/aidlc-docs/inception/plans/README.md
+++ b/aidlc-docs/inception/plans/README.md
@@ -11,8 +11,8 @@
 
 | 檔案 | 說明 |
 |---|---|
-| [`development-plan.html`](development-plan.html) | 9 pillar / 26 user story 的 wave-based 開發計劃；含 Kanban 看板、相依圖、story table、pillar 細節、NFR 與風險。**建議用瀏覽器開啟**：`open aidlc-docs/inception/plans/development-plan.html`。 |
-| [GitHub Project (live)](https://github.com/users/Dannielchung/projects/1) | live kanban，26 個 draft items，欄位：Wave / Pillar / Story ID。可直接拖卡片改 status |
+| [`development-plan.html`](development-plan.html) | 9 個支柱 / 26 條 user story 的 wave-based 開發計劃，內容已繁中化；含 Kanban 看板、相依圖、story table、pillar 細節、NFR 與風險。**建議用瀏覽器開啟**：`open aidlc-docs/inception/plans/development-plan.html`。 |
+| [GitHub Project（live）](https://github.com/users/opendiamonds/projects/16) | live kanban，26 個 draft items（標題前綴 `[Cloud-360]`），自訂欄位：Wave / Pillar / Story ID。Status 內建 Backlog / Ready / In progress / In review / Done。可直接拖卡片改狀態。 |
 
 ### 與其他 inception 子目錄的關係
 
@@ -38,8 +38,8 @@
 
 | File | Purpose |
 |---|---|
-| [`development-plan.html`](development-plan.html) | Wave-based development plan covering all 9 pillars and 26 user stories; includes Kanban board, dependency graph, story table, pillar details, NFRs, and known risks. **Open in a browser**: `open aidlc-docs/inception/plans/development-plan.html`. |
-| [GitHub Project (live)](https://github.com/users/Dannielchung/projects/1) | Live kanban with 26 draft items; custom fields Wave / Pillar / Story ID. Drag cards to update status. |
+| [`development-plan.html`](development-plan.html) | Wave-based development plan covering all 9 pillars and 26 user stories (content rendered in Traditional Chinese); includes Kanban board, dependency graph, story table, pillar details, NFRs, and known risks. **Open in a browser**: `open aidlc-docs/inception/plans/development-plan.html`. |
+| [GitHub Project (live)](https://github.com/users/opendiamonds/projects/16) | Live kanban with 26 draft items prefixed `[Cloud-360]`; custom fields Wave / Pillar / Story ID. Built-in Status: Backlog / Ready / In progress / In review / Done. Drag cards to update. |
 
 ### Relationship to other inception subdirectories
 

--- a/aidlc-docs/inception/plans/README.md
+++ b/aidlc-docs/inception/plans/README.md
@@ -1,0 +1,54 @@
+# Inception Plans
+
+> AIDLC inception-phase planning artifacts for Cloud-360.
+> Cloud-360 inception 階段的規劃產出。
+
+## 中文版
+
+### 目錄內容
+
+`aidlc-docs/inception/plans/` 存放 AIDLC inception 階段（workflow planning / unit planning / cross-pillar 排程）的規劃產出。
+
+| 檔案 | 說明 |
+|---|---|
+| [`development-plan.html`](development-plan.html) | 9 pillar / 26 user story 的 wave-based 開發計劃；含相依圖、story table、pillar 細節、NFR 與風險。**建議用瀏覽器開啟**：`open aidlc-docs/inception/plans/development-plan.html`。 |
+
+### 與其他 inception 子目錄的關係
+
+- `requirements/` — SRS（需求規格）來源。
+- `user-stories/` — pillar 與 user stories 來源。
+- `application-design/` — system architecture（agent routing、integration layer 等）。
+- `decisions/` — ADRs（架構級決策）。
+- `plans/`（**本目錄**） — 把上述輸入整理成可執行的 wave 與 sprint。
+
+### 維護準則
+
+- 計劃檔案（HTML / md）更新時要記錄到 `aidlc-docs/audit.md`。
+- 涉及範圍變動（例如新增 pillar、wave 重切）需另開 ADR。
+- markdown 檔案（例如本 README）必須雙語（per ADR-0005）；HTML 內也建議含中英對照區塊。
+
+---
+
+## English Version
+
+### Contents
+
+`aidlc-docs/inception/plans/` holds AIDLC inception-phase planning artifacts: workflow planning, unit planning, cross-pillar scheduling.
+
+| File | Purpose |
+|---|---|
+| [`development-plan.html`](development-plan.html) | Wave-based development plan covering all 9 pillars and 26 user stories; includes dependency graph, story table, pillar details, NFRs, and known risks. **Open in a browser**: `open aidlc-docs/inception/plans/development-plan.html`. |
+
+### Relationship to other inception subdirectories
+
+- `requirements/` — SRS source.
+- `user-stories/` — pillars and user stories source.
+- `application-design/` — system architecture (agent routing, integration layer, etc.).
+- `decisions/` — ADRs (architecture decisions).
+- `plans/` (**this directory**) — turns the above into executable waves and sprints.
+
+### Maintenance rules
+
+- Updates to plan files (HTML or md) are recorded in `aidlc-docs/audit.md`.
+- Scope changes (new pillar, wave restructure) require a new ADR.
+- Markdown files (this README included) must be bilingual per ADR-0005; HTML files are encouraged to include side-by-side Chinese/English sections.

--- a/aidlc-docs/inception/plans/development-plan.html
+++ b/aidlc-docs/inception/plans/development-plan.html
@@ -1,0 +1,845 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cloud-360 開發計劃 / Development Plan</title>
+<style>
+  :root {
+    --bg: #0f172a;
+    --card: #1e293b;
+    --card-2: #273548;
+    --accent: #38bdf8;
+    --accent2: #fbbf24;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --border: #334155;
+    --w0: #f43f5e;
+    --w1: #38bdf8;
+    --w2: #34d399;
+    --w3: #fbbf24;
+    --done: #22c55e;
+    --pending: #94a3b8;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+                 "PingFang TC", "Microsoft JhengHei", "Noto Sans TC", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+  }
+  .container { max-width: 1200px; margin: 0 auto; padding: 2rem 1.5rem; }
+  header {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1.5rem;
+    margin-bottom: 2rem;
+  }
+  header h1 {
+    font-size: 2.1rem;
+    margin: 0 0 0.4rem;
+    background: linear-gradient(90deg, var(--accent), var(--accent2));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .subtitle { color: var(--muted); font-size: 0.95rem; }
+  .meta-row { color: var(--muted); font-size: 0.8rem; margin-top: 0.4rem; }
+  nav.toc {
+    background: var(--card);
+    padding: 0.9rem 1.2rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+    border-left: 3px solid var(--accent2);
+  }
+  nav.toc strong { color: var(--accent2); margin-right: 0.6rem; }
+  nav.toc a {
+    color: var(--accent);
+    text-decoration: none;
+    margin-right: 1rem;
+    font-size: 0.9rem;
+  }
+  nav.toc a:hover { text-decoration: underline; }
+
+  section { margin: 2.5rem 0; scroll-margin-top: 1rem; }
+  h2 {
+    font-size: 1.4rem;
+    border-left: 4px solid var(--accent);
+    padding-left: 0.75rem;
+    margin: 2.5rem 0 1rem;
+  }
+  h3 { font-size: 1.15rem; margin: 1.25rem 0 0.75rem; }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0 0.5rem;
+  }
+  .stat {
+    background: var(--card);
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    border-left: 3px solid var(--accent);
+  }
+  .stat .num {
+    font-size: 1.9rem;
+    font-weight: 700;
+    color: var(--accent);
+    line-height: 1.1;
+  }
+  .stat .label { color: var(--muted); font-size: 0.85rem; margin-top: 0.2rem; }
+
+  .wave {
+    background: var(--card);
+    border-radius: 8px;
+    padding: 1.4rem 1.6rem;
+    margin-bottom: 1.2rem;
+    border-top: 4px solid var(--accent);
+  }
+  .wave.w0 { border-top-color: var(--w0); }
+  .wave.w1 { border-top-color: var(--w1); }
+  .wave.w2 { border-top-color: var(--w2); }
+  .wave.w3 { border-top-color: var(--w3); }
+  .wave h3 { margin-top: 0; display: flex; align-items: baseline; flex-wrap: wrap; gap: 0.6rem; }
+  .wave .goal { color: var(--muted); margin-bottom: 0.8rem; font-size: 0.93rem; }
+  .wave .meta {
+    display: flex;
+    gap: 1.4rem;
+    flex-wrap: wrap;
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin: 0.3rem 0 0.9rem;
+  }
+  .wave .meta b { color: var(--text); }
+  .wave .stories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+  .story-chip {
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    color: var(--text);
+  }
+  .story-chip .id {
+    color: var(--accent2);
+    font-weight: 700;
+    margin-right: 0.3rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.6rem;
+    font-size: 0.9rem;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  th { background: rgba(56, 189, 248, 0.08); color: var(--accent); font-weight: 600; }
+  tr:hover td { background: rgba(255, 255, 255, 0.02); }
+  td.id-cell { color: var(--accent2); font-weight: 700; white-space: nowrap; }
+  td.wave-cell { white-space: nowrap; }
+
+  .pillar {
+    background: var(--card);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+    margin-bottom: 1rem;
+    border-left: 3px solid var(--accent);
+  }
+  .pillar h3 { margin-top: 0; display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
+  .pillar-id {
+    background: var(--accent);
+    color: var(--bg);
+    padding: 0.15rem 0.55rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+  .pillar p.summary { color: var(--muted); margin: 0.3rem 0 0.9rem; font-size: 0.93rem; }
+  .pillar .story {
+    border-left: 2px solid var(--border);
+    padding: 0.4rem 0 0.4rem 1rem;
+    margin: 0.6rem 0;
+  }
+  .pillar .story-id { color: var(--accent2); font-weight: 700; font-size: 0.85rem; }
+  .pillar .story-title { font-weight: 600; }
+  .pillar .story-criteria { color: var(--muted); font-size: 0.85rem; margin-top: 0.25rem; }
+  .pillar .story-criteria li { margin: 0.2rem 0; }
+
+  .wave-tag {
+    display: inline-block;
+    padding: 0.1rem 0.55rem;
+    border-radius: 12px;
+    font-size: 0.72rem;
+    font-weight: 700;
+  }
+  .wave-tag.w0 { background: rgba(244, 63, 94, 0.2); color: var(--w0); }
+  .wave-tag.w1 { background: rgba(56, 189, 248, 0.2); color: var(--w1); }
+  .wave-tag.w2 { background: rgba(52, 211, 153, 0.2); color: var(--w2); }
+  .wave-tag.w3 { background: rgba(251, 191, 36, 0.2); color: var(--w3); }
+
+  .mermaid-wrapper {
+    background: var(--card);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+    text-align: center;
+  }
+
+  .bilingual {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  @media (max-width: 768px) { .bilingual { grid-template-columns: 1fr; } }
+  .lang-zh, .lang-en {
+    background: var(--card-2);
+    padding: 1rem 1.1rem;
+    border-radius: 6px;
+    font-size: 0.92rem;
+  }
+  .lang-zh::before {
+    content: "中文版";
+    display: block;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+    letter-spacing: 0.5px;
+  }
+  .lang-en::before {
+    content: "ENGLISH";
+    display: block;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+    letter-spacing: 0.5px;
+  }
+
+  .nfr-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.8rem;
+  }
+  .nfr-item {
+    background: var(--card);
+    padding: 0.7rem 1rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    border-left: 3px solid var(--accent2);
+  }
+
+  .risks { padding-left: 1.3rem; }
+  .risks li { margin-bottom: 0.6rem; }
+
+  code, kbd {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+    font-family: "SF Mono", Menlo, Consolas, "Roboto Mono", monospace;
+  }
+
+  footer {
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  footer a { color: var(--accent); }
+
+  @media print {
+    body { background: white; color: black; }
+    .wave, .pillar, .stat, .mermaid-wrapper, .lang-zh, .lang-en, .nfr-item, nav.toc {
+      background: #f8f8f8;
+      border: 1px solid #ddd;
+    }
+    a { color: #0369a1; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+  <header>
+    <h1>Cloud-360 開發計劃 / Development Plan</h1>
+    <div class="subtitle">9 Pillars · 26 User Stories · 4 Waves · AIDLC v0.1.8 inception artifact</div>
+    <div class="meta-row">
+      Generated 2026-05-09 · Source: <code>aidlc-docs/inception/{requirements,user-stories,application-design}/</code> · Status: Draft
+    </div>
+  </header>
+
+  <nav class="toc">
+    <strong>目錄</strong>
+    <a href="#summary">總覽</a>
+    <a href="#waves">4 個 Wave</a>
+    <a href="#dep-graph">相依圖</a>
+    <a href="#story-table">26 條 Stories</a>
+    <a href="#pillars">9 個 Pillar 細節</a>
+    <a href="#nfr">非功能性需求</a>
+    <a href="#risks">風險與待解</a>
+    <a href="#nextsteps">下一步</a>
+  </nav>
+
+  <section id="summary">
+    <h2>1. 總覽 / Overview</h2>
+    <div class="bilingual">
+      <div class="lang-zh">
+        Cloud-360 是 AI-native 多雲架構與維運平台，目前 SDD baseline 已寫入 9 大 pillar、26 條 user stories；尚未產製 application code。本計劃把這些 stories 依相依性切成 4 個 wave，從基礎設施（MCP/Skill registry、Agent Routing 骨架、Desktop shell）開始，逐步堆疊核心差異化功能、FinOps/Ops/Mobile 配套與擴充規範。
+      </div>
+      <div class="lang-en">
+        Cloud-360 is an AI-native multi-cloud architecture & operations platform. The SDD baseline currently captures 9 pillars and 26 user stories; no application code yet. This plan groups the stories into 4 waves by dependency, starting with foundational pieces (MCP/Skill registry, Agent Routing skeleton, Desktop shell) and progressively layering core differentiators, FinOps/Ops/Mobile supporting features, and extension governance.
+      </div>
+    </div>
+
+    <div class="stat-grid">
+      <div class="stat"><div class="num">9</div><div class="label">Core pillars (A–I)</div></div>
+      <div class="stat"><div class="num">26</div><div class="label">User stories</div></div>
+      <div class="stat"><div class="num">4</div><div class="label">Delivery waves</div></div>
+      <div class="stat"><div class="num">3</div><div class="label">Cloud providers (AWS / GCP / Azure)</div></div>
+      <div class="stat"><div class="num">0</div><div class="label">Application code yet</div></div>
+      <div class="stat"><div class="num">2</div><div class="label">Web targets (Desktop + Mobile PWA)</div></div>
+    </div>
+  </section>
+
+  <section id="waves">
+    <h2>2. 4 個 Wave / Delivery Waves</h2>
+
+    <div class="wave w0">
+      <h3>Wave 0 <span class="wave-tag w0">Foundation</span></h3>
+      <div class="goal">先做基礎設施才會有東西可裝。<br><span style="color:var(--muted)">Build the foundation that everything else relies on.</span></div>
+      <div class="meta">
+        <span><b>Stories:</b> 8</span>
+        <span><b>Deps:</b> none</span>
+        <span><b>Theme:</b> Registry · Routing · Auth · Shell</span>
+      </div>
+      <div class="stories">
+        <span class="story-chip"><span class="id">I1</span>MCP Server Registry</span>
+        <span class="story-chip"><span class="id">I2</span>Skill Catalog</span>
+        <span class="story-chip"><span class="id">I3</span>Tool Permission/Risk Model</span>
+        <span class="story-chip"><span class="id">I4</span>MCP/Skill Approval Workflow</span>
+        <span class="story-chip"><span class="id">I5</span>Agent Tool Selection Observability</span>
+        <span class="story-chip"><span class="id">F1</span>AI Chat Cloud Query (read-only)</span>
+        <span class="story-chip"><span class="id">F2</span>AI Chat Cloud Operation (with approval)</span>
+        <span class="story-chip"><span class="id">H1</span>Desktop Web Full Workspace shell</span>
+      </div>
+    </div>
+
+    <div class="wave w1">
+      <h3>Wave 1 <span class="wave-tag w1">Core Differentiators</span></h3>
+      <div class="goal">使用者最有感的入口：自然語言設計 + 共編 draw.io、選型與 IaC、安全檢視。<br><span style="color:var(--muted)">The signature capabilities users come for.</span></div>
+      <div class="meta">
+        <span><b>Stories:</b> 9</span>
+        <span><b>Deps:</b> Wave 0</span>
+        <span><b>Theme:</b> Architecture · Selection · IaC · Security</span>
+      </div>
+      <div class="stories">
+        <span class="story-chip"><span class="id">A1</span>Natural Language → Architecture</span>
+        <span class="story-chip"><span class="id">A2</span>Well-Architected Review</span>
+        <span class="story-chip"><span class="id">A3</span>AI + draw.io Co-editing</span>
+        <span class="story-chip"><span class="id">B1</span>Service Comparison Matrix</span>
+        <span class="story-chip"><span class="id">B2</span>Workload-Based Recommendation</span>
+        <span class="story-chip"><span class="id">D1</span>Modular IaC Generation</span>
+        <span class="story-chip"><span class="id">D2</span>IaC Security Scan</span>
+        <span class="story-chip"><span class="id">G1</span>Multi-Cloud Security Review</span>
+        <span class="story-chip"><span class="id">G2</span>Least-Privilege Analysis</span>
+      </div>
+    </div>
+
+    <div class="wave w2">
+      <h3>Wave 2 <span class="wave-tag w2">FinOps · Ops · Mobile</span></h3>
+      <div class="goal">把 architecture graph 餵給 FinOps / Ops，把 Mobile Web approval 補齊。<br><span style="color:var(--muted)">Cost insights, ops optimization, and mobile companion.</span></div>
+      <div class="meta">
+        <span><b>Stories:</b> 8</span>
+        <span><b>Deps:</b> Wave 1（FinOps/Ops 需要 architecture graph）</span>
+        <span><b>Theme:</b> Cost · Ops · Mobile · Agentic</span>
+      </div>
+      <div class="stories">
+        <span class="story-chip"><span class="id">C1</span>Monthly TCO Estimation</span>
+        <span class="story-chip"><span class="id">C2</span>Spot/Preemptible Comparison</span>
+        <span class="story-chip"><span class="id">C3</span>Cross-Cloud Egress Analysis</span>
+        <span class="story-chip"><span class="id">E1</span>Right-sizing Recommendation</span>
+        <span class="story-chip"><span class="id">E2</span>Architecture Modernization</span>
+        <span class="story-chip"><span class="id">F3</span>Agentic AI Operations</span>
+        <span class="story-chip"><span class="id">H2</span>Mobile Web Ops Companion</span>
+        <span class="story-chip"><span class="id">H3</span>Mobile Web Approval (MFA/WebAuthn)</span>
+      </div>
+    </div>
+
+    <div class="wave w3">
+      <h3>Wave 3 <span class="wave-tag w3">Extensions / Governance Depth</span></h3>
+      <div class="goal">Policy-as-Code 自動產生、深層 audit 與可重用治理規則。<br><span style="color:var(--muted)">Policy-as-Code automation and deeper governance.</span></div>
+      <div class="meta">
+        <span><b>Stories:</b> 1</span>
+        <span><b>Deps:</b> Wave 1（G1/G2 finding stream）</span>
+        <span><b>Theme:</b> Policy-as-Code</span>
+      </div>
+      <div class="stories">
+        <span class="story-chip"><span class="id">G3</span>Policy-as-Code Recommendation (OPA / Sentinel / Azure Policy / GCP Org Policy / AWS Config rule)</span>
+      </div>
+    </div>
+  </section>
+
+  <section id="dep-graph">
+    <h2>3. Wave 相依圖 / Dependency Graph</h2>
+    <div class="mermaid-wrapper">
+      <pre class="mermaid">
+flowchart LR
+  classDef w0 fill:#3a1a25,stroke:#f43f5e,color:#fda4af;
+  classDef w1 fill:#0c2e44,stroke:#38bdf8,color:#bae6fd;
+  classDef w2 fill:#0f3a2a,stroke:#34d399,color:#bbf7d0;
+  classDef w3 fill:#3a2e0c,stroke:#fbbf24,color:#fde68a;
+
+  W0["<b>Wave 0 — Foundation</b><br/>I1 I2 I3 I4 I5<br/>F1 F2<br/>H1 + Auth/RBAC/MFA/WebAuthn"]:::w0
+  W1["<b>Wave 1 — Core Differentiators</b><br/>A1 A2 A3<br/>B1 B2<br/>D1 D2<br/>G1 G2"]:::w1
+  W2["<b>Wave 2 — FinOps · Ops · Mobile</b><br/>C1 C2 C3<br/>E1 E2<br/>F3<br/>H2 H3"]:::w2
+  W3["<b>Wave 3 — Extensions</b><br/>G3 (Policy-as-Code)"]:::w3
+
+  W0 --> W1
+  W1 --> W2
+  W1 --> W3
+  W2 -.optional.-> W3
+      </pre>
+    </div>
+  </section>
+
+  <section id="story-table">
+    <h2>4. 26 條 User Stories（含 Wave 與相依）</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Title</th>
+          <th>Pillar</th>
+          <th>Wave</th>
+          <th>Key dependencies</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="id-cell">A1</td><td>Natural Language to Architecture</td><td>A · Architecture Design</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Routing Agent (W0), Intent Parser, Design Agent</td></tr>
+        <tr><td class="id-cell">A2</td><td>Well-Architected Review</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>A1 output, Provider best-practice rules</td></tr>
+        <tr><td class="id-cell">A3</td><td>AI + draw.io Co-editing</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>draw.io XML adapter → Architecture Graph</td></tr>
+        <tr><td class="id-cell">B1</td><td>Service Comparison Matrix</td><td>B · Cross-Cloud Selection</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Cloud catalog data source</td></tr>
+        <tr><td class="id-cell">B2</td><td>Workload-Based Recommendation</td><td>B</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>B1 + Component Selection Agent</td></tr>
+        <tr><td class="id-cell">C1</td><td>Monthly TCO Estimation</td><td>C · FinOps</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph (W1), pricing API</td></tr>
+        <tr><td class="id-cell">C2</td><td>Spot/Preemptible Comparison</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>C1 base pricing</td></tr>
+        <tr><td class="id-cell">C3</td><td>Cross-Cloud Egress Analysis</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph traffic edges</td></tr>
+        <tr><td class="id-cell">D1</td><td>Modular IaC Generation</td><td>D · IaC</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Architecture Graph (W1), provider templates</td></tr>
+        <tr><td class="id-cell">D2</td><td>IaC Security Scan</td><td>D</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>D1 output, tfsec/trivy/Checkov MCP</td></tr>
+        <tr><td class="id-cell">E1</td><td>Right-sizing Recommendation</td><td>E · Operations</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Cloud metrics MCP, Approval Gate</td></tr>
+        <tr><td class="id-cell">E2</td><td>Architecture Modernization</td><td>E</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph + provider new-service catalog</td></tr>
+        <tr><td class="id-cell">F1</td><td>AI Chat Cloud Query (read-only)</td><td>F · AI Multi-Cloud Ops</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>MCP registry (I1), Agent Routing</td></tr>
+        <tr><td class="id-cell">F2</td><td>AI Chat Cloud Operation</td><td>F</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>F1 + Approval Gate + Risk Model (I3)</td></tr>
+        <tr><td class="id-cell">F3</td><td>Agentic AI Operations</td><td>F</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Provider signal pipelines + Memory + Routing</td></tr>
+        <tr><td class="id-cell">G1</td><td>Multi-Cloud Security Review</td><td>G · Security Posture</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>IAM/Config/SCC/Defender MCP, finding store</td></tr>
+        <tr><td class="id-cell">G2</td><td>Least-Privilege Analysis</td><td>G</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>G1 + IAM Access Analyzer-style data</td></tr>
+        <tr><td class="id-cell">G3</td><td>Policy-as-Code Recommendation</td><td>G</td><td class="wave-cell"><span class="wave-tag w3">W3</span></td><td>G1+G2 findings, Approval Gate</td></tr>
+        <tr><td class="id-cell">H1</td><td>Desktop Web Full Workspace</td><td>H · Web UX</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>API Gateway, Auth (RBAC/MFA/WebAuthn)</td></tr>
+        <tr><td class="id-cell">H2</td><td>Mobile Web Ops Companion</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Responsive web shell, F1/F3 outputs</td></tr>
+        <tr><td class="id-cell">H3</td><td>Mobile Web Approval</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>H2 + WebAuthn / Passkey integration</td></tr>
+        <tr><td class="id-cell">I1</td><td>MCP Server Registry</td><td>I · MCP &amp; Skill Mgmt</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>(foundation)</td></tr>
+        <tr><td class="id-cell">I2</td><td>Skill Catalog</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1</td></tr>
+        <tr><td class="id-cell">I3</td><td>Tool Permission/Risk Model</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1 + I2</td></tr>
+        <tr><td class="id-cell">I4</td><td>MCP/Skill Approval Workflow</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I3 + Audit log</td></tr>
+        <tr><td class="id-cell">I5</td><td>Agent Tool Selection Observability</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I4 + Routing trace + Audit</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="pillars">
+    <h2>5. 9 個 Pillar 細節 / Pillar Details</h2>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">A</span>Architecture Design <span class="wave-tag w1">Wave 1</span></h3>
+      <p class="summary">把自然語言需求轉成單雲／多雲架構藍圖，整合 Mermaid / PlantUML / draw.io，並支援 Active-Active / Active-Passive cross-cloud DR。</p>
+      <div class="story">
+        <div><span class="story-id">A1</span> · <span class="story-title">Natural Language to Architecture</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>萃取 workload、HA、DR、scalability、region、security、compliance 需求</li>
+            <li>產生 Mermaid / PlantUML / draw.io 輸出</li>
+            <li>說明 assumption 與 trade-off</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">A2</span> · <span class="story-title">Well-Architected Review</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>覆蓋 reliability / security / cost / operational excellence / performance 五支柱</li>
+            <li>產生 severity、impact、remediation 建議</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">A3</span> · <span class="story-title">AI + draw.io Co-editing</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>支援 <code>.drawio</code> / XML source format</li>
+            <li>AI 可加 / 刪 node、改 connection、標 data flow</li>
+            <li>每次 AI 修改有 change summary 與 version history</li>
+            <li>圖面可解析成 architecture graph 給其他 agent 共用</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">B</span>Cross-Cloud Component Selection <span class="wave-tag w1">Wave 1</span></h3>
+      <p class="summary">依 workload profile 比較 AWS / GCP / Azure 同質託管服務，輸出 SLA、limits、lock-in、cost、ops complexity 與替代方案。</p>
+      <div class="story">
+        <div><span class="story-id">B1</span> · <span class="story-title">Service Comparison Matrix</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>含 SLA、限制、相容性、成本風險、lock-in、維運複雜度</li>
+            <li>覆蓋 compute、database、storage、network、Kubernetes、messaging、AI/ML</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">B2</span> · <span class="story-title">Workload-Based Recommendation</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>使用 QPS、concurrency、data size、latency、region、compliance 限制</li>
+            <li>提供 rationale、alternatives、known limitations</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">C</span>Cost Estimation &amp; FinOps <span class="wave-tag w2">Wave 2</span></h3>
+      <p class="summary">估算多雲 TCO、比較 Spot / Preemptible、計算跨雲 / 跨區 egress、提出 right-sizing 建議。</p>
+      <div class="story">
+        <div><span class="story-id">C1</span> · <span class="story-title">Monthly TCO Estimation</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>估算 compute、database、cache、storage、network、CDN、egress、observability</li>
+            <li>顯示 pricing assumption 與來源 timestamp</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">C2</span> · <span class="story-title">Spot / Preemptible Comparison</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>覆蓋 AWS Spot、Azure Spot、GCP Spot / Preemptible</li>
+            <li>含 savings estimate 與 interruption risk</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">C3</span> · <span class="story-title">Cross-Cloud Egress Analysis</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>區分 intra-region、inter-region、internet egress、cross-cloud traffic</li>
+            <li>標出昂貴 / 高風險 traffic path</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">D</span>Terraform / OpenTofu IaC <span class="wave-tag w1">Wave 1</span></h3>
+      <p class="summary">把確認後的架構轉為 Terraform / OpenTofu 模組草稿，支援 aws / google / azurerm provider，整合靜態安全掃描。</p>
+      <div class="story">
+        <div><span class="story-id">D1</span> · <span class="story-title">Modular IaC Generation</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>產出 <code>providers.tf</code>、<code>main.tf</code>、<code>variables.tf</code>、<code>outputs.tf</code> 與 <code>modules/</code></li>
+            <li>支援 aws / google / azurerm provider</li>
+            <li>禁止產生 plaintext secret</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">D2</span> · <span class="story-title">IaC Security Scan</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>支援 tfsec、trivy、Checkov</li>
+            <li>標出 public storage、過寬 ingress、缺加密、過寬 IAM/RBAC</li>
+            <li>產出 remediation guidance</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">E</span>Operations Optimization <span class="wave-tag w2">Wave 2</span></h3>
+      <p class="summary">針對部署中或設計中的架構持續做健康檢查、效能、可用性與現代化建議。</p>
+      <div class="story">
+        <div><span class="story-id">E1</span> · <span class="story-title">Right-sizing Recommendation</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>分析 CPU、memory、IOPS、network、storage</li>
+            <li>估算改動後的成本影響</li>
+            <li>調整 production 資源前需 approval</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">E2</span> · <span class="story-title">Architecture Modernization</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>找出 legacy / 高維運成本 / 高雲費的服務</li>
+            <li>建議 managed、serverless、container、event-driven 替代</li>
+            <li>含 migration risk 與預期效益</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">F</span>AI Multi-Cloud Operations <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
+      <p class="summary">透過 AI Chat 與 Agentic AI 管理多雲環境；高風險操作必經 human approval；所有操作寫 audit log。</p>
+      <div class="story">
+        <div><span class="story-id">F1</span> · <span class="story-title">AI Chat Cloud Query</span> <span class="wave-tag w0">W0</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>支援 account / project / subscription、region 選擇</li>
+            <li>查 inventory、cost、metrics、logs、IAM/security findings</li>
+            <li>含 data source 與 query time，遮罩 secrets</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">F2</span> · <span class="story-title">AI Chat Cloud Operation</span> <span class="wave-tag w0">W0</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>Read-only action 經 policy 分類後可執行</li>
+            <li>Write / delete / deploy / permission change 需 human approval</li>
+            <li>顯示 plan、impact、rollback、verification step</li>
+            <li>記錄 audit log</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">F3</span> · <span class="story-title">Agentic AI Operations</span> <span class="wave-tag w2">W2</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>背景 agent 偵測 cost spike、安全風險、可用性缺口、效能瓶頸</li>
+            <li>產出建議與 remediation plan</li>
+            <li>無 explicit approval 時不執行高風險變更</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">G</span>Cloud Security Posture &amp; Policy Advisory <span class="wave-tag w1">Wave 1</span> <span class="wave-tag w3">Wave 3</span></h3>
+      <p class="summary">整合 AWS Config / Security Hub / GuardDuty / GCP SCC / Org Policy / Azure Policy / Defender 等資料源，提出可執行的治理建議。</p>
+      <div class="story">
+        <div><span class="story-id">G1</span> · <span class="story-title">Multi-Cloud Security Review</span> <span class="wave-tag w1">W1</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>檢查 IAM/RBAC、network exposure、storage access、encryption、audit logging、policy guardrails</li>
+            <li>產出 severity、evidence、impact、remediation</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">G2</span> · <span class="story-title">Least-Privilege Analysis</span> <span class="wave-tag w1">W1</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>偵測 wildcard permissions、stale identities、unused permissions</li>
+            <li>產出 least-privilege 建議</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">G3</span> · <span class="story-title">Policy-as-Code Recommendation</span> <span class="wave-tag w3">W3</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>支援 Terraform patch、OPA / Rego、Sentinel、Azure Policy、GCP Org Policy、AWS Config rule</li>
+            <li>套用前需 approval</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">H</span>Web-Based Desktop &amp; Mobile Experience <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
+      <p class="summary">Desktop Web 為完整工作台、Mobile Web 走 PWA 走伴隨介面；不做 native iOS / Android app。</p>
+      <div class="story">
+        <div><span class="story-id">H1</span> · <span class="story-title">Desktop Web Full Workspace</span> <span class="wave-tag w0">W0</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>支援 AI Chat、draw.io editor、IaC editor、FinOps / Security / Ops dashboard、agent trace、approval mgmt console</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">H2</span> · <span class="story-title">Mobile Web Ops Companion</span> <span class="wave-tag w2">W2</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>Responsive web / PWA</li>
+            <li>支援 AI Chat、alerts、approvals、health digest、findings、readonly diagram</li>
+            <li>不需 native iOS / Android app</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">H3</span> · <span class="story-title">Mobile Web Approval</span> <span class="wave-tag w2">W2</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>顯示 plan、affected resources、risk、impact、rollback</li>
+            <li>高風險 approval 需 MFA、Passkey 或 WebAuthn</li>
+            <li>記錄 audit log，支援 timeout / escalation</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="pillar">
+      <h3><span class="pillar-id">I</span>MCP &amp; Skill Management <span class="wave-tag w0">Wave 0</span></h3>
+      <p class="summary">整個治理層的命脈：MCP server registry、skill catalog、權限／風險模型、approval workflow、observability。</p>
+      <div class="story">
+        <div><span class="story-id">I1</span> · <span class="story-title">MCP Server Registry</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>欄位：name、endpoint/transport、owner、environment、auth scope、enabled、version</li>
+            <li>支援 health check（availability、schema 相容、latency、recent errors）</li>
+            <li>禁存 secrets 於 config 或 log</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">I2</span> · <span class="story-title">Skill Catalog</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>追蹤 skill name、domain、owner、version、description、required tools、risk level、change log</li>
+            <li>支援 enable / disable / deprecate / rollback</li>
+            <li>顯示 skill ↔ MCP tool ↔ SDK/CLI ↔ provider 的相依關係</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">I3</span> · <span class="story-title">Tool Permission &amp; Risk Model</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>分類：read-only、write、deploy、delete、permission-change、production-impacting</li>
+            <li>高風險 tool 啟用或執行前需 approval</li>
+            <li>Agent Routing Layer 必須在選 tool 前看分類</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">I4</span> · <span class="story-title">MCP / Skill Approval Workflow</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>新增高風險 tool、擴 auth scope、停用 critical tool 都要 review</li>
+            <li>停用需 impact summary 與 rollback plan</li>
+            <li>所有變更寫 audit log</li>
+          </ul>
+        </div>
+      </div>
+      <div class="story">
+        <div><span class="story-id">I5</span> · <span class="story-title">Agent Tool Selection Observability</span></div>
+        <div class="story-criteria">
+          <ul>
+            <li>顯示選用的 tool/skill、原因、input summary、permission level、approval status、execution result</li>
+            <li>遮罩 secrets 與敏感 payload</li>
+            <li>把 tool execution 連回原始 user request、agent trace、audit log</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="nfr">
+    <h2>6. 非功能性需求 / NFR (cross-cutting)</h2>
+    <div class="bilingual">
+      <div class="lang-zh">
+        所有 wave 的 story 在 construction 階段都必須對齊以下 NFR；它們是 SRS §7 的 hard constraints。
+      </div>
+      <div class="lang-en">
+        Every wave's stories must align with these NFRs during construction; they are hard constraints from SRS §7.
+      </div>
+    </div>
+    <div class="nfr-grid" style="margin-top:0.8rem;">
+      <div class="nfr-item">Security by default</div>
+      <div class="nfr-item">Auditability（所有操作有 audit log）</div>
+      <div class="nfr-item">RBAC and least privilege</div>
+      <div class="nfr-item">Human approval gate for high-risk action</div>
+      <div class="nfr-item">Multi-cloud extensibility</div>
+      <div class="nfr-item">Explainable AI decisions</div>
+      <div class="nfr-item">Reproducible IaC generation</div>
+      <div class="nfr-item">Recommendation vs execution 分離</div>
+      <div class="nfr-item">Responsive Web 支援桌機 / 平板 / 手機</div>
+      <div class="nfr-item">Governed MCP / Skill lifecycle</div>
+      <div class="nfr-item">Bilingual documentation（per ADR-0005）</div>
+      <div class="nfr-item">Property-based testing on IaC / cost / routing</div>
+    </div>
+  </section>
+
+  <section id="risks">
+    <h2>7. 已知風險與待解 / Risks &amp; Open Questions</h2>
+    <ul class="risks">
+      <li><b>Wave 0 太重</b>：MCP/Skill registry + Routing + Auth + Desktop shell 一次做太多。建議再細切成 W0a（registry + permission model + audit）／W0b（routing + chat shell）／W0c（desktop UI + auth）三個 sub-wave。</li>
+      <li><b>Architecture Graph 設計</b>：A3 → C/D/E/G 都要吃 architecture graph。Schema 沒對齊就會回頭翻工。建議在 Wave 0 末或 Wave 1 起手就把 graph schema 先定下來（單獨 ADR）。</li>
+      <li><b>Pricing 來源時效性</b>：C 系列要靠雲端 pricing API，價格資訊有時效；要規範 cache TTL、source timestamp、stale fallback。</li>
+      <li><b>跨雲 IAM 概念對齊</b>：G1/G2 要把 AWS IAM、GCP IAM、Azure RBAC 的差異攤平到統一 finding model，定義權限抽象層。</li>
+      <li><b>Approval Gate UX</b>：F2、E1、H3 都會經 approval。Approval payload schema 統一才能在 Mobile Web 安全展開（H3 需 MFA / WebAuthn）。</li>
+      <li><b>Agentic AI 的副作用控制</b>：F3 背景 agent 不可在沒 approval 時做高風險變更。建議用 Guardrail Agent + 預設 read-only。</li>
+      <li><b>Test 與 property-based 範圍</b>：cost calculator、IaC generator、routing 是預設 enable 的 property-based extension。要在 wave 進入 construction 前先寫 property 草稿。</li>
+    </ul>
+  </section>
+
+  <section id="nextsteps">
+    <h2>8. 下一步 / Next Steps</h2>
+    <ol>
+      <li><b>Workflow Planning（推薦下一步）</b>：以本計劃為輸入，跑 AIDLC <code>workflow-planning.md</code>，把每個 wave 拆成可執行的 unit / sprint。</li>
+      <li><b>NFR 落地</b>：把 SRS §7 的 NFR 各自寫成可驗收條件，作為 construction 階段的 hard constraint。</li>
+      <li><b>Wave 0 細切</b>：拆 W0a / W0b / W0c，避免「foundation 做太久卻沒可見成果」。</li>
+      <li><b>Architecture Graph schema ADR</b>：開 ADR-0007，定義 internal architecture graph 的 schema、序列化、版本策略。</li>
+      <li><b>Reverse Engineering</b>：repo 裡的 <code>firebase_templates/</code>、<code>workflows/n8n/</code>、<code>tools/</code> 跑一次 AIDLC reverse-engineering 對齊新 SRS，標出可重用 vs 要丟。</li>
+      <li><b>啟動 Pillar I 的 inception → construction</b>：Pillar I（MCP &amp; Skill Mgmt）是其他 pillar 的前置。建議第一個跑完 AIDLC 全 inception 階段。</li>
+    </ol>
+  </section>
+
+  <footer>
+    <p>
+      Generated 2026-05-09 · Source files:
+      <code>aidlc-docs/inception/requirements/cloud-360-srs.md</code>,
+      <code>aidlc-docs/inception/user-stories/core-pillars.md</code>,
+      <code>aidlc-docs/inception/application-design/system-architecture.md</code>.
+    </p>
+    <p>
+      AIDLC v0.1.8 · Pre-enabled extensions: <code>security/baseline</code>, <code>testing/property-based</code>, <code>bilingual-docs</code>.
+      To open this file: <kbd>open aidlc-docs/inception/plans/development-plan.html</kbd>
+    </p>
+  </footer>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script>
+  if (window.mermaid) {
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'dark',
+      themeVariables: {
+        primaryColor: '#1e293b',
+        primaryTextColor: '#e2e8f0',
+        primaryBorderColor: '#38bdf8',
+        lineColor: '#94a3b8',
+        background: '#0f172a',
+      },
+    });
+  }
+</script>
+</body>
+</html>

--- a/aidlc-docs/inception/plans/development-plan.html
+++ b/aidlc-docs/inception/plans/development-plan.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Cloud-360 開發計劃 / Development Plan</title>
+<title>Cloud-360 開發計劃</title>
 <style>
   :root {
     --bg: #0f172a;
@@ -387,18 +387,18 @@
 <div class="container">
 
   <header>
-    <h1>Cloud-360 開發計劃 / Development Plan</h1>
-    <div class="subtitle">9 Pillars · 26 User Stories · 4 Waves · AIDLC v0.1.8 inception artifact</div>
+    <h1>Cloud-360 開發計劃</h1>
+    <div class="subtitle">9 個支柱 · 26 條 User Story · 4 個 Wave · AIDLC v0.1.8 inception 階段產物</div>
     <div class="meta-row">
-      Generated 2026-05-09 · Updated 2026-05-10 · Source: <code>aidlc-docs/inception/{requirements,user-stories,application-design}/</code> · Status: Draft
+      建立 2026-05-09 · 更新 2026-05-10 · 來源：<code>aidlc-docs/inception/{requirements,user-stories,application-design}/</code> · 狀態：Draft
     </div>
     <div style="margin-top:0.9rem;">
-      <a href="https://github.com/users/Dannielchung/projects/1"
+      <a href="https://github.com/users/opendiamonds/projects/16"
          target="_blank" rel="noopener noreferrer"
          style="display:inline-flex; align-items:center; gap:0.5rem; padding:0.55rem 1rem; background:linear-gradient(90deg,var(--accent),var(--accent2)); color:#0f172a; font-weight:700; text-decoration:none; border-radius:6px; font-size:0.9rem;">
-        ▶ View on GitHub Project (live kanban)
+        ▶ 開啟 GitHub Project（live 看板）
       </a>
-      <span style="color:var(--muted); font-size:0.82rem; margin-left:0.7rem;">本 HTML 是靜態快照；GitHub Project 是 live 看板，可拖卡片改 status</span>
+      <span style="color:var(--muted); font-size:0.82rem; margin-left:0.7rem;">本 HTML 是靜態快照；GitHub Project 為 live 看板，可拖卡片改 status</span>
     </div>
   </header>
 
@@ -415,37 +415,32 @@
   </nav>
 
   <section id="summary">
-    <h2>1. 總覽 / Overview</h2>
-    <div class="bilingual">
-      <div class="lang-zh">
-        Cloud-360 是 AI-native 多雲架構與維運平台，目前 SDD baseline 已寫入 9 大 pillar、26 條 user stories；尚未產製 application code。本計劃把這些 stories 依相依性切成 4 個 wave，從基礎設施（MCP/Skill registry、Agent Routing 骨架、Desktop shell）開始，逐步堆疊核心差異化功能、FinOps/Ops/Mobile 配套與擴充規範。
-      </div>
-      <div class="lang-en">
-        Cloud-360 is an AI-native multi-cloud architecture & operations platform. The SDD baseline currently captures 9 pillars and 26 user stories; no application code yet. This plan groups the stories into 4 waves by dependency, starting with foundational pieces (MCP/Skill registry, Agent Routing skeleton, Desktop shell) and progressively layering core differentiators, FinOps/Ops/Mobile supporting features, and extension governance.
-      </div>
-    </div>
+    <h2>1. 總覽</h2>
+    <p style="font-size:0.95rem; line-height:1.7;">
+      Cloud-360 是 AI-native 多雲架構與維運平台，目前 SDD baseline 已寫入 9 大支柱、26 條 user stories；尚未產製 application code。本計劃把這些 stories 依相依性切成 4 個 wave，從基礎建設（MCP/Skill registry、Agent Routing 骨架、Desktop shell）開始，逐步堆疊核心差異化功能、FinOps/維運/Mobile 配套與擴充規範。
+    </p>
 
     <div class="stat-grid">
-      <div class="stat"><div class="num">9</div><div class="label">Core pillars (A–I)</div></div>
+      <div class="stat"><div class="num">9</div><div class="label">核心支柱（A–I）</div></div>
       <div class="stat"><div class="num">26</div><div class="label">User stories</div></div>
-      <div class="stat"><div class="num">4</div><div class="label">Delivery waves</div></div>
-      <div class="stat"><div class="num">3</div><div class="label">Cloud providers (AWS / GCP / Azure)</div></div>
-      <div class="stat"><div class="num">0</div><div class="label">Application code yet</div></div>
-      <div class="stat"><div class="num">2</div><div class="label">Web targets (Desktop + Mobile PWA)</div></div>
+      <div class="stat"><div class="num">4</div><div class="label">交付 wave</div></div>
+      <div class="stat"><div class="num">3</div><div class="label">雲端供應商（AWS / GCP / Azure）</div></div>
+      <div class="stat"><div class="num">0</div><div class="label">尚未產製 application code</div></div>
+      <div class="stat"><div class="num">2</div><div class="label">Web 目標（Desktop + Mobile PWA）</div></div>
     </div>
   </section>
 
   <section id="kanban">
-    <h2>2. Kanban 看板 / Wave-based Kanban</h2>
+    <h2>2. Kanban 看板 / Wave 看板</h2>
     <p style="color:var(--muted); font-size:0.92rem;">
-      四欄看板對應 4 個 delivery wave；卡片左邊色條同 wave。<a href="https://github.com/users/Dannielchung/projects/1" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">在 GitHub Project 上拖卡片可改 Status / Wave</a>，本 HTML 是靜態快照。
+      四欄看板對應 4 個交付 wave；卡片左邊色條同 wave。<a href="https://github.com/users/opendiamonds/projects/16" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">在 GitHub Project 上可拖卡片改 Status / Wave</a>，本 HTML 為靜態快照。
     </p>
 
     <div class="kanban-legend">
-      <span class="kanban-legend-item"><span class="kanban-legend-dot w0"></span>W0 Foundation · 8 stories · no deps</span>
-      <span class="kanban-legend-item"><span class="kanban-legend-dot w1"></span>W1 Core · 9 stories · ← W0</span>
-      <span class="kanban-legend-item"><span class="kanban-legend-dot w2"></span>W2 FinOps/Ops/Mobile · 8 stories · ← W1</span>
-      <span class="kanban-legend-item"><span class="kanban-legend-dot w3"></span>W3 Extensions · 1 story · ← W1</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w0"></span>W0 基礎建設 · 8 條 · 無前置</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w1"></span>W1 核心差異化 · 9 條 · 接 W0</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w2"></span>W2 FinOps · 維運 · Mobile · 8 條 · 接 W1</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w3"></span>W3 擴充 · 1 條 · 接 W1</span>
     </div>
 
     <div class="kanban">
@@ -453,188 +448,188 @@
       <!-- W0 -->
       <div class="kanban-col w0">
         <div class="kanban-col-header">
-          <div class="kanban-col-title">Wave 0 — Foundation <span class="wave-tag w0">8</span></div>
-          <div class="kanban-col-meta">Registry · Routing · Auth · Shell · no deps</div>
+          <div class="kanban-col-title">Wave 0 — 基礎建設 <span class="wave-tag w0">8</span></div>
+          <div class="kanban-col-meta">Registry · Routing · Auth · Shell · 無前置</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">I1</div>
           <div class="kanban-card-title">MCP Server Registry</div>
           <span class="kanban-card-pillar">I MCP/Skill</span>
-          <div class="kanban-card-deps">Deps: foundation</div>
+          <div class="kanban-card-deps">前置：基礎</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">I2</div>
           <div class="kanban-card-title">Skill Catalog</div>
           <span class="kanban-card-pillar">I MCP/Skill</span>
-          <div class="kanban-card-deps">Deps: I1</div>
+          <div class="kanban-card-deps">前置：I1</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">I3</div>
-          <div class="kanban-card-title">Tool Permission &amp; Risk Model</div>
+          <div class="kanban-card-title">Tool 權限與風險模型</div>
           <span class="kanban-card-pillar">I MCP/Skill</span>
-          <div class="kanban-card-deps">Deps: I1, I2</div>
+          <div class="kanban-card-deps">前置：I1、I2</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">I4</div>
-          <div class="kanban-card-title">MCP / Skill Approval Workflow</div>
+          <div class="kanban-card-title">MCP / Skill 審批流程</div>
           <span class="kanban-card-pillar">I MCP/Skill</span>
-          <div class="kanban-card-deps">Deps: I1–I3, Audit</div>
+          <div class="kanban-card-deps">前置：I1–I3、Audit</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">I5</div>
-          <div class="kanban-card-title">Agent Tool Selection Observability</div>
+          <div class="kanban-card-title">Agent Tool 選用可觀察性</div>
           <span class="kanban-card-pillar">I MCP/Skill</span>
-          <div class="kanban-card-deps">Deps: I1–I4, Routing trace</div>
+          <div class="kanban-card-deps">前置：I1–I4、Routing trace</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">F1</div>
-          <div class="kanban-card-title">AI Chat Cloud Query (read-only)</div>
-          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
-          <div class="kanban-card-deps">Deps: I1, Agent Routing</div>
+          <div class="kanban-card-title">AI Chat 雲端查詢（read-only）</div>
+          <span class="kanban-card-pillar">F AI 多雲</span>
+          <div class="kanban-card-deps">前置：I1、Agent Routing</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">F2</div>
-          <div class="kanban-card-title">AI Chat Cloud Operation (with approval)</div>
-          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
-          <div class="kanban-card-deps">Deps: F1, Approval Gate, I3</div>
+          <div class="kanban-card-title">AI Chat 雲端操作（含 approval）</div>
+          <span class="kanban-card-pillar">F AI 多雲</span>
+          <div class="kanban-card-deps">前置：F1、Approval Gate、I3</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">H1</div>
-          <div class="kanban-card-title">Desktop Web Full Workspace</div>
-          <span class="kanban-card-pillar">H Web UX</span>
-          <div class="kanban-card-deps">Deps: API GW, Auth/MFA/WebAuthn</div>
+          <div class="kanban-card-title">桌面 Web 完整工作台</div>
+          <span class="kanban-card-pillar">H Web 體驗</span>
+          <div class="kanban-card-deps">前置：API GW、Auth/MFA/WebAuthn</div>
         </div>
       </div>
 
       <!-- W1 -->
       <div class="kanban-col w1">
         <div class="kanban-col-header">
-          <div class="kanban-col-title">Wave 1 — Core <span class="wave-tag w1">9</span></div>
-          <div class="kanban-col-meta">Architecture · Selection · IaC · Security · ← W0</div>
+          <div class="kanban-col-title">Wave 1 — 核心差異化 <span class="wave-tag w1">9</span></div>
+          <div class="kanban-col-meta">架構 · 選型 · IaC · 安全 · 接 W0</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">A1</div>
-          <div class="kanban-card-title">Natural Language → Architecture</div>
-          <span class="kanban-card-pillar">A Architecture</span>
-          <div class="kanban-card-deps">Deps: Routing (W0), Intent Parser, Design Agent</div>
+          <div class="kanban-card-title">自然語言轉架構藍圖</div>
+          <span class="kanban-card-pillar">A 架構設計</span>
+          <div class="kanban-card-deps">前置：Routing（W0）、Intent Parser、Design Agent</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">A2</div>
-          <div class="kanban-card-title">Well-Architected Review</div>
-          <span class="kanban-card-pillar">A Architecture</span>
-          <div class="kanban-card-deps">Deps: A1, provider best-practice rules</div>
+          <div class="kanban-card-title">Well-Architected 架構檢查</div>
+          <span class="kanban-card-pillar">A 架構設計</span>
+          <div class="kanban-card-deps">前置：A1、provider best-practice 規則</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">A3</div>
-          <div class="kanban-card-title">AI + draw.io Co-editing</div>
-          <span class="kanban-card-pillar">A Architecture</span>
-          <div class="kanban-card-deps">Deps: draw.io XML adapter → Architecture Graph</div>
+          <div class="kanban-card-title">AI + draw.io 共同編輯</div>
+          <span class="kanban-card-pillar">A 架構設計</span>
+          <div class="kanban-card-deps">前置：draw.io XML adapter → Architecture Graph</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">B1</div>
-          <div class="kanban-card-title">Service Comparison Matrix</div>
-          <span class="kanban-card-pillar">B Cross-Cloud</span>
-          <div class="kanban-card-deps">Deps: cloud catalog data</div>
+          <div class="kanban-card-title">服務比較矩陣</div>
+          <span class="kanban-card-pillar">B 跨雲選型</span>
+          <div class="kanban-card-deps">前置：雲端服務目錄資料</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">B2</div>
-          <div class="kanban-card-title">Workload-Based Recommendation</div>
-          <span class="kanban-card-pillar">B Cross-Cloud</span>
-          <div class="kanban-card-deps">Deps: B1 + Component Selection Agent</div>
+          <div class="kanban-card-title">依工作負載推薦元件</div>
+          <span class="kanban-card-pillar">B 跨雲選型</span>
+          <div class="kanban-card-deps">前置：B1 + Component Selection Agent</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">D1</div>
-          <div class="kanban-card-title">Modular IaC Generation</div>
+          <div class="kanban-card-title">模組化 IaC 產生</div>
           <span class="kanban-card-pillar">D IaC</span>
-          <div class="kanban-card-deps">Deps: Architecture Graph, provider templates</div>
+          <div class="kanban-card-deps">前置：Architecture Graph、provider 範本</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">D2</div>
-          <div class="kanban-card-title">IaC Security Scan</div>
+          <div class="kanban-card-title">IaC 安全掃描</div>
           <span class="kanban-card-pillar">D IaC</span>
-          <div class="kanban-card-deps">Deps: D1, tfsec/trivy/Checkov MCP</div>
+          <div class="kanban-card-deps">前置：D1、tfsec/trivy/Checkov MCP</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">G1</div>
-          <div class="kanban-card-title">Multi-Cloud Security Review</div>
-          <span class="kanban-card-pillar">G Security</span>
-          <div class="kanban-card-deps">Deps: IAM/Config/SCC/Defender MCP</div>
+          <div class="kanban-card-title">多雲安全姿態檢視</div>
+          <span class="kanban-card-pillar">G 安全</span>
+          <div class="kanban-card-deps">前置：IAM/Config/SCC/Defender MCP</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">G2</div>
-          <div class="kanban-card-title">Least-Privilege Analysis</div>
-          <span class="kanban-card-pillar">G Security</span>
-          <div class="kanban-card-deps">Deps: G1 + IAM Access Analyzer-style data</div>
+          <div class="kanban-card-title">最小權限分析</div>
+          <span class="kanban-card-pillar">G 安全</span>
+          <div class="kanban-card-deps">前置：G1 + IAM Access Analyzer 等資料</div>
         </div>
       </div>
 
       <!-- W2 -->
       <div class="kanban-col w2">
         <div class="kanban-col-header">
-          <div class="kanban-col-title">Wave 2 — FinOps · Ops · Mobile <span class="wave-tag w2">8</span></div>
-          <div class="kanban-col-meta">Cost · Ops · Mobile · Agentic · ← W1</div>
+          <div class="kanban-col-title">Wave 2 — FinOps · 維運 · Mobile <span class="wave-tag w2">8</span></div>
+          <div class="kanban-col-meta">成本 · 維運 · Mobile · Agentic · 接 W1</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">C1</div>
-          <div class="kanban-card-title">Monthly TCO Estimation</div>
+          <div class="kanban-card-title">月費 TCO 估算</div>
           <span class="kanban-card-pillar">C FinOps</span>
-          <div class="kanban-card-deps">Deps: Architecture Graph, pricing API</div>
+          <div class="kanban-card-deps">前置：Architecture Graph、pricing API</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">C2</div>
-          <div class="kanban-card-title">Spot / Preemptible Comparison</div>
+          <div class="kanban-card-title">Spot / Preemptible 計費比較</div>
           <span class="kanban-card-pillar">C FinOps</span>
-          <div class="kanban-card-deps">Deps: C1 base pricing</div>
+          <div class="kanban-card-deps">前置：C1 基礎價格</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">C3</div>
-          <div class="kanban-card-title">Cross-Cloud Egress Analysis</div>
+          <div class="kanban-card-title">跨雲流量成本分析</div>
           <span class="kanban-card-pillar">C FinOps</span>
-          <div class="kanban-card-deps">Deps: Architecture Graph traffic edges</div>
+          <div class="kanban-card-deps">前置：Architecture Graph traffic edges</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">E1</div>
-          <div class="kanban-card-title">Right-sizing Recommendation</div>
-          <span class="kanban-card-pillar">E Operations</span>
-          <div class="kanban-card-deps">Deps: cloud metrics MCP, Approval Gate</div>
+          <div class="kanban-card-title">Right-sizing 建議</div>
+          <span class="kanban-card-pillar">E 維運</span>
+          <div class="kanban-card-deps">前置：雲端 metrics MCP、Approval Gate</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">E2</div>
-          <div class="kanban-card-title">Architecture Modernization</div>
-          <span class="kanban-card-pillar">E Operations</span>
-          <div class="kanban-card-deps">Deps: Architecture Graph + new-service catalog</div>
+          <div class="kanban-card-title">架構現代化建議</div>
+          <span class="kanban-card-pillar">E 維運</span>
+          <div class="kanban-card-deps">前置：Architecture Graph + 新服務目錄</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">F3</div>
-          <div class="kanban-card-title">Agentic AI Operations</div>
-          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
-          <div class="kanban-card-deps">Deps: provider signal pipelines + Memory + Routing</div>
+          <div class="kanban-card-title">Agentic AI 主動分析</div>
+          <span class="kanban-card-pillar">F AI 多雲</span>
+          <div class="kanban-card-deps">前置：provider signal pipelines + Memory + Routing</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">H2</div>
-          <div class="kanban-card-title">Mobile Web Ops Companion</div>
-          <span class="kanban-card-pillar">H Web UX</span>
-          <div class="kanban-card-deps">Deps: responsive shell, F1/F3 outputs</div>
+          <div class="kanban-card-title">行動 Web 維運伴隨介面</div>
+          <span class="kanban-card-pillar">H Web 體驗</span>
+          <div class="kanban-card-deps">前置：responsive shell、F1/F3 輸出</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">H3</div>
-          <div class="kanban-card-title">Mobile Web Approval (MFA/WebAuthn)</div>
-          <span class="kanban-card-pillar">H Web UX</span>
-          <div class="kanban-card-deps">Deps: H2 + WebAuthn / Passkey</div>
+          <div class="kanban-card-title">行動 Web 審批（MFA / WebAuthn）</div>
+          <span class="kanban-card-pillar">H Web 體驗</span>
+          <div class="kanban-card-deps">前置：H2 + WebAuthn / Passkey</div>
         </div>
       </div>
 
       <!-- W3 -->
       <div class="kanban-col w3">
         <div class="kanban-col-header">
-          <div class="kanban-col-title">Wave 3 — Extensions <span class="wave-tag w3">1</span></div>
-          <div class="kanban-col-meta">Policy-as-Code · ← W1</div>
+          <div class="kanban-col-title">Wave 3 — 擴充 <span class="wave-tag w3">1</span></div>
+          <div class="kanban-col-meta">Policy-as-Code · 接 W1</div>
         </div>
         <div class="kanban-card">
           <div class="kanban-card-id">G3</div>
-          <div class="kanban-card-title">Policy-as-Code Recommendation</div>
-          <span class="kanban-card-pillar">G Security</span>
-          <div class="kanban-card-deps">Deps: G1+G2 findings, Approval Gate. Targets: OPA/Rego, Sentinel, Azure Policy, GCP Org Policy, AWS Config rule</div>
+          <div class="kanban-card-title">Policy-as-Code 建議</div>
+          <span class="kanban-card-pillar">G 安全</span>
+          <div class="kanban-card-deps">前置：G1+G2 findings、Approval Gate。目標：OPA/Rego、Sentinel、Azure Policy、GCP Org Policy、AWS Config rule</div>
         </div>
       </div>
 
@@ -642,7 +637,7 @@
   </section>
 
   <section id="dep-graph">
-    <h2>3. Wave 相依圖 / Dependency Graph</h2>
+    <h2>3. Wave 相依圖</h2>
     <div class="mermaid-wrapper">
       <pre class="mermaid">
 flowchart LR
@@ -651,15 +646,15 @@ flowchart LR
   classDef w2 fill:#0f3a2a,stroke:#34d399,color:#bbf7d0;
   classDef w3 fill:#3a2e0c,stroke:#fbbf24,color:#fde68a;
 
-  W0["<b>Wave 0 — Foundation</b><br/>I1 I2 I3 I4 I5<br/>F1 F2<br/>H1 + Auth/RBAC/MFA/WebAuthn"]:::w0
-  W1["<b>Wave 1 — Core Differentiators</b><br/>A1 A2 A3<br/>B1 B2<br/>D1 D2<br/>G1 G2"]:::w1
-  W2["<b>Wave 2 — FinOps · Ops · Mobile</b><br/>C1 C2 C3<br/>E1 E2<br/>F3<br/>H2 H3"]:::w2
-  W3["<b>Wave 3 — Extensions</b><br/>G3 (Policy-as-Code)"]:::w3
+  W0["<b>Wave 0 — 基礎建設</b><br/>I1 I2 I3 I4 I5<br/>F1 F2<br/>H1 + Auth/RBAC/MFA/WebAuthn"]:::w0
+  W1["<b>Wave 1 — 核心差異化</b><br/>A1 A2 A3<br/>B1 B2<br/>D1 D2<br/>G1 G2"]:::w1
+  W2["<b>Wave 2 — FinOps · 維運 · Mobile</b><br/>C1 C2 C3<br/>E1 E2<br/>F3<br/>H2 H3"]:::w2
+  W3["<b>Wave 3 — 擴充</b><br/>G3 Policy-as-Code"]:::w3
 
   W0 --> W1
   W1 --> W2
   W1 --> W3
-  W2 -.optional.-> W3
+  W2 -.選用.-> W3
       </pre>
     </div>
   </section>
@@ -669,40 +664,40 @@ flowchart LR
     <table>
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Title</th>
-          <th>Pillar</th>
+          <th>編號</th>
+          <th>標題</th>
+          <th>支柱</th>
           <th>Wave</th>
-          <th>Key dependencies</th>
+          <th>主要前置</th>
         </tr>
       </thead>
       <tbody>
-        <tr><td class="id-cell">A1</td><td>Natural Language to Architecture</td><td>A · Architecture Design</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Routing Agent (W0), Intent Parser, Design Agent</td></tr>
-        <tr><td class="id-cell">A2</td><td>Well-Architected Review</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>A1 output, Provider best-practice rules</td></tr>
-        <tr><td class="id-cell">A3</td><td>AI + draw.io Co-editing</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>draw.io XML adapter → Architecture Graph</td></tr>
-        <tr><td class="id-cell">B1</td><td>Service Comparison Matrix</td><td>B · Cross-Cloud Selection</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Cloud catalog data source</td></tr>
-        <tr><td class="id-cell">B2</td><td>Workload-Based Recommendation</td><td>B</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>B1 + Component Selection Agent</td></tr>
-        <tr><td class="id-cell">C1</td><td>Monthly TCO Estimation</td><td>C · FinOps</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph (W1), pricing API</td></tr>
-        <tr><td class="id-cell">C2</td><td>Spot/Preemptible Comparison</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>C1 base pricing</td></tr>
-        <tr><td class="id-cell">C3</td><td>Cross-Cloud Egress Analysis</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph traffic edges</td></tr>
-        <tr><td class="id-cell">D1</td><td>Modular IaC Generation</td><td>D · IaC</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Architecture Graph (W1), provider templates</td></tr>
-        <tr><td class="id-cell">D2</td><td>IaC Security Scan</td><td>D</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>D1 output, tfsec/trivy/Checkov MCP</td></tr>
-        <tr><td class="id-cell">E1</td><td>Right-sizing Recommendation</td><td>E · Operations</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Cloud metrics MCP, Approval Gate</td></tr>
-        <tr><td class="id-cell">E2</td><td>Architecture Modernization</td><td>E</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph + provider new-service catalog</td></tr>
-        <tr><td class="id-cell">F1</td><td>AI Chat Cloud Query (read-only)</td><td>F · AI Multi-Cloud Ops</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>MCP registry (I1), Agent Routing</td></tr>
-        <tr><td class="id-cell">F2</td><td>AI Chat Cloud Operation</td><td>F</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>F1 + Approval Gate + Risk Model (I3)</td></tr>
-        <tr><td class="id-cell">F3</td><td>Agentic AI Operations</td><td>F</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Provider signal pipelines + Memory + Routing</td></tr>
-        <tr><td class="id-cell">G1</td><td>Multi-Cloud Security Review</td><td>G · Security Posture</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>IAM/Config/SCC/Defender MCP, finding store</td></tr>
-        <tr><td class="id-cell">G2</td><td>Least-Privilege Analysis</td><td>G</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>G1 + IAM Access Analyzer-style data</td></tr>
-        <tr><td class="id-cell">G3</td><td>Policy-as-Code Recommendation</td><td>G</td><td class="wave-cell"><span class="wave-tag w3">W3</span></td><td>G1+G2 findings, Approval Gate</td></tr>
-        <tr><td class="id-cell">H1</td><td>Desktop Web Full Workspace</td><td>H · Web UX</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>API Gateway, Auth (RBAC/MFA/WebAuthn)</td></tr>
-        <tr><td class="id-cell">H2</td><td>Mobile Web Ops Companion</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Responsive web shell, F1/F3 outputs</td></tr>
-        <tr><td class="id-cell">H3</td><td>Mobile Web Approval</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>H2 + WebAuthn / Passkey integration</td></tr>
-        <tr><td class="id-cell">I1</td><td>MCP Server Registry</td><td>I · MCP &amp; Skill Mgmt</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>(foundation)</td></tr>
+        <tr><td class="id-cell">A1</td><td>自然語言轉架構藍圖</td><td>A · 架構設計</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Routing Agent（W0）、Intent Parser、Design Agent</td></tr>
+        <tr><td class="id-cell">A2</td><td>Well-Architected 架構檢查</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>A1 輸出、provider best-practice 規則</td></tr>
+        <tr><td class="id-cell">A3</td><td>AI + draw.io 共同編輯</td><td>A</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>draw.io XML adapter → Architecture Graph</td></tr>
+        <tr><td class="id-cell">B1</td><td>服務比較矩陣</td><td>B · 跨雲選型</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>雲端服務目錄資料</td></tr>
+        <tr><td class="id-cell">B2</td><td>依工作負載推薦元件</td><td>B</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>B1 + Component Selection Agent</td></tr>
+        <tr><td class="id-cell">C1</td><td>月費 TCO 估算</td><td>C · FinOps</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph（W1）、pricing API</td></tr>
+        <tr><td class="id-cell">C2</td><td>Spot / Preemptible 計費比較</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>C1 基礎價格</td></tr>
+        <tr><td class="id-cell">C3</td><td>跨雲流量成本分析</td><td>C</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph traffic edges</td></tr>
+        <tr><td class="id-cell">D1</td><td>模組化 IaC 產生</td><td>D · IaC</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>Architecture Graph（W1）、provider 範本</td></tr>
+        <tr><td class="id-cell">D2</td><td>IaC 安全掃描</td><td>D</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>D1 輸出、tfsec/trivy/Checkov MCP</td></tr>
+        <tr><td class="id-cell">E1</td><td>Right-sizing 建議</td><td>E · 維運</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>雲端 metrics MCP、Approval Gate</td></tr>
+        <tr><td class="id-cell">E2</td><td>架構現代化建議</td><td>E</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>Architecture Graph + provider 新服務目錄</td></tr>
+        <tr><td class="id-cell">F1</td><td>AI Chat 雲端查詢（read-only）</td><td>F · AI 多雲</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>MCP registry（I1）、Agent Routing</td></tr>
+        <tr><td class="id-cell">F2</td><td>AI Chat 雲端操作（含 approval）</td><td>F</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>F1 + Approval Gate + Risk Model（I3）</td></tr>
+        <tr><td class="id-cell">F3</td><td>Agentic AI 主動分析</td><td>F</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>provider signal pipelines + Memory + Routing</td></tr>
+        <tr><td class="id-cell">G1</td><td>多雲安全姿態檢視</td><td>G · 安全</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>IAM/Config/SCC/Defender MCP、finding store</td></tr>
+        <tr><td class="id-cell">G2</td><td>最小權限分析</td><td>G</td><td class="wave-cell"><span class="wave-tag w1">W1</span></td><td>G1 + IAM Access Analyzer 等資料</td></tr>
+        <tr><td class="id-cell">G3</td><td>Policy-as-Code 建議</td><td>G</td><td class="wave-cell"><span class="wave-tag w3">W3</span></td><td>G1+G2 findings、Approval Gate</td></tr>
+        <tr><td class="id-cell">H1</td><td>桌面 Web 完整工作台</td><td>H · Web 體驗</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>API Gateway、Auth（RBAC/MFA/WebAuthn）</td></tr>
+        <tr><td class="id-cell">H2</td><td>行動 Web 維運伴隨介面</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>responsive web shell、F1/F3 輸出</td></tr>
+        <tr><td class="id-cell">H3</td><td>行動 Web 審批</td><td>H</td><td class="wave-cell"><span class="wave-tag w2">W2</span></td><td>H2 + WebAuthn / Passkey 整合</td></tr>
+        <tr><td class="id-cell">I1</td><td>MCP Server Registry</td><td>I · MCP/Skill 管理</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>（基礎，無前置）</td></tr>
         <tr><td class="id-cell">I2</td><td>Skill Catalog</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1</td></tr>
-        <tr><td class="id-cell">I3</td><td>Tool Permission/Risk Model</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1 + I2</td></tr>
-        <tr><td class="id-cell">I4</td><td>MCP/Skill Approval Workflow</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I3 + Audit log</td></tr>
-        <tr><td class="id-cell">I5</td><td>Agent Tool Selection Observability</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I4 + Routing trace + Audit</td></tr>
+        <tr><td class="id-cell">I3</td><td>Tool 權限與風險模型</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1 + I2</td></tr>
+        <tr><td class="id-cell">I4</td><td>MCP / Skill 審批流程</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I3 + Audit log</td></tr>
+        <tr><td class="id-cell">I5</td><td>Agent Tool 選用可觀察性</td><td>I</td><td class="wave-cell"><span class="wave-tag w0">W0</span></td><td>I1–I4 + Routing trace + Audit</td></tr>
       </tbody>
     </table>
   </section>
@@ -711,10 +706,10 @@ flowchart LR
     <h2>5. 9 個 Pillar 細節 / Pillar Details</h2>
 
     <div class="pillar">
-      <h3><span class="pillar-id">A</span>Architecture Design <span class="wave-tag w1">Wave 1</span></h3>
+      <h3><span class="pillar-id">A</span>架構設計 <span class="wave-tag w1">Wave 1</span></h3>
       <p class="summary">把自然語言需求轉成單雲／多雲架構藍圖，整合 Mermaid / PlantUML / draw.io，並支援 Active-Active / Active-Passive cross-cloud DR。</p>
       <div class="story">
-        <div><span class="story-id">A1</span> · <span class="story-title">Natural Language to Architecture</span></div>
+        <div><span class="story-id">A1</span> · <span class="story-title">自然語言轉架構藍圖</span></div>
         <div class="story-criteria">
           <ul>
             <li>萃取 workload、HA、DR、scalability、region、security、compliance 需求</li>
@@ -724,7 +719,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">A2</span> · <span class="story-title">Well-Architected Review</span></div>
+        <div><span class="story-id">A2</span> · <span class="story-title">Well-Architected 架構檢查</span></div>
         <div class="story-criteria">
           <ul>
             <li>覆蓋 reliability / security / cost / operational excellence / performance 五支柱</li>
@@ -733,7 +728,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">A3</span> · <span class="story-title">AI + draw.io Co-editing</span></div>
+        <div><span class="story-id">A3</span> · <span class="story-title">AI + draw.io 共同編輯</span></div>
         <div class="story-criteria">
           <ul>
             <li>支援 <code>.drawio</code> / XML source format</li>
@@ -746,10 +741,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">B</span>Cross-Cloud Component Selection <span class="wave-tag w1">Wave 1</span></h3>
+      <h3><span class="pillar-id">B</span>跨雲元件選型 <span class="wave-tag w1">Wave 1</span></h3>
       <p class="summary">依 workload profile 比較 AWS / GCP / Azure 同質託管服務，輸出 SLA、limits、lock-in、cost、ops complexity 與替代方案。</p>
       <div class="story">
-        <div><span class="story-id">B1</span> · <span class="story-title">Service Comparison Matrix</span></div>
+        <div><span class="story-id">B1</span> · <span class="story-title">服務比較矩陣</span></div>
         <div class="story-criteria">
           <ul>
             <li>含 SLA、限制、相容性、成本風險、lock-in、維運複雜度</li>
@@ -758,7 +753,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">B2</span> · <span class="story-title">Workload-Based Recommendation</span></div>
+        <div><span class="story-id">B2</span> · <span class="story-title">依工作負載推薦元件</span></div>
         <div class="story-criteria">
           <ul>
             <li>使用 QPS、concurrency、data size、latency、region、compliance 限制</li>
@@ -769,10 +764,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">C</span>Cost Estimation &amp; FinOps <span class="wave-tag w2">Wave 2</span></h3>
+      <h3><span class="pillar-id">C</span>成本估算與 FinOps <span class="wave-tag w2">Wave 2</span></h3>
       <p class="summary">估算多雲 TCO、比較 Spot / Preemptible、計算跨雲 / 跨區 egress、提出 right-sizing 建議。</p>
       <div class="story">
-        <div><span class="story-id">C1</span> · <span class="story-title">Monthly TCO Estimation</span></div>
+        <div><span class="story-id">C1</span> · <span class="story-title">月費 TCO 估算</span></div>
         <div class="story-criteria">
           <ul>
             <li>估算 compute、database、cache、storage、network、CDN、egress、observability</li>
@@ -781,7 +776,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">C2</span> · <span class="story-title">Spot / Preemptible Comparison</span></div>
+        <div><span class="story-id">C2</span> · <span class="story-title">Spot / Preemptible 計費比較</span></div>
         <div class="story-criteria">
           <ul>
             <li>覆蓋 AWS Spot、Azure Spot、GCP Spot / Preemptible</li>
@@ -790,7 +785,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">C3</span> · <span class="story-title">Cross-Cloud Egress Analysis</span></div>
+        <div><span class="story-id">C3</span> · <span class="story-title">跨雲流量成本分析</span></div>
         <div class="story-criteria">
           <ul>
             <li>區分 intra-region、inter-region、internet egress、cross-cloud traffic</li>
@@ -804,7 +799,7 @@ flowchart LR
       <h3><span class="pillar-id">D</span>Terraform / OpenTofu IaC <span class="wave-tag w1">Wave 1</span></h3>
       <p class="summary">把確認後的架構轉為 Terraform / OpenTofu 模組草稿，支援 aws / google / azurerm provider，整合靜態安全掃描。</p>
       <div class="story">
-        <div><span class="story-id">D1</span> · <span class="story-title">Modular IaC Generation</span></div>
+        <div><span class="story-id">D1</span> · <span class="story-title">模組化 IaC 產生</span></div>
         <div class="story-criteria">
           <ul>
             <li>產出 <code>providers.tf</code>、<code>main.tf</code>、<code>variables.tf</code>、<code>outputs.tf</code> 與 <code>modules/</code></li>
@@ -814,7 +809,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">D2</span> · <span class="story-title">IaC Security Scan</span></div>
+        <div><span class="story-id">D2</span> · <span class="story-title">IaC 安全掃描</span></div>
         <div class="story-criteria">
           <ul>
             <li>支援 tfsec、trivy、Checkov</li>
@@ -826,10 +821,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">E</span>Operations Optimization <span class="wave-tag w2">Wave 2</span></h3>
+      <h3><span class="pillar-id">E</span>維運最佳化 <span class="wave-tag w2">Wave 2</span></h3>
       <p class="summary">針對部署中或設計中的架構持續做健康檢查、效能、可用性與現代化建議。</p>
       <div class="story">
-        <div><span class="story-id">E1</span> · <span class="story-title">Right-sizing Recommendation</span></div>
+        <div><span class="story-id">E1</span> · <span class="story-title">Right-sizing 建議</span></div>
         <div class="story-criteria">
           <ul>
             <li>分析 CPU、memory、IOPS、network、storage</li>
@@ -839,7 +834,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">E2</span> · <span class="story-title">Architecture Modernization</span></div>
+        <div><span class="story-id">E2</span> · <span class="story-title">架構現代化建議</span></div>
         <div class="story-criteria">
           <ul>
             <li>找出 legacy / 高維運成本 / 高雲費的服務</li>
@@ -851,10 +846,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">F</span>AI Multi-Cloud Operations <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
+      <h3><span class="pillar-id">F</span>AI 多雲維運 <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
       <p class="summary">透過 AI Chat 與 Agentic AI 管理多雲環境；高風險操作必經 human approval；所有操作寫 audit log。</p>
       <div class="story">
-        <div><span class="story-id">F1</span> · <span class="story-title">AI Chat Cloud Query</span> <span class="wave-tag w0">W0</span></div>
+        <div><span class="story-id">F1</span> · <span class="story-title">AI Chat 雲端查詢</span> <span class="wave-tag w0">W0</span></div>
         <div class="story-criteria">
           <ul>
             <li>支援 account / project / subscription、region 選擇</li>
@@ -864,7 +859,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">F2</span> · <span class="story-title">AI Chat Cloud Operation</span> <span class="wave-tag w0">W0</span></div>
+        <div><span class="story-id">F2</span> · <span class="story-title">AI Chat 雲端操作</span> <span class="wave-tag w0">W0</span></div>
         <div class="story-criteria">
           <ul>
             <li>Read-only action 經 policy 分類後可執行</li>
@@ -875,7 +870,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">F3</span> · <span class="story-title">Agentic AI Operations</span> <span class="wave-tag w2">W2</span></div>
+        <div><span class="story-id">F3</span> · <span class="story-title">Agentic AI 主動分析</span> <span class="wave-tag w2">W2</span></div>
         <div class="story-criteria">
           <ul>
             <li>背景 agent 偵測 cost spike、安全風險、可用性缺口、效能瓶頸</li>
@@ -887,10 +882,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">G</span>Cloud Security Posture &amp; Policy Advisory <span class="wave-tag w1">Wave 1</span> <span class="wave-tag w3">Wave 3</span></h3>
+      <h3><span class="pillar-id">G</span>安全姿態與政策諮詢 <span class="wave-tag w1">Wave 1</span> <span class="wave-tag w3">Wave 3</span></h3>
       <p class="summary">整合 AWS Config / Security Hub / GuardDuty / GCP SCC / Org Policy / Azure Policy / Defender 等資料源，提出可執行的治理建議。</p>
       <div class="story">
-        <div><span class="story-id">G1</span> · <span class="story-title">Multi-Cloud Security Review</span> <span class="wave-tag w1">W1</span></div>
+        <div><span class="story-id">G1</span> · <span class="story-title">多雲安全姿態檢視</span> <span class="wave-tag w1">W1</span></div>
         <div class="story-criteria">
           <ul>
             <li>檢查 IAM/RBAC、network exposure、storage access、encryption、audit logging、policy guardrails</li>
@@ -899,7 +894,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">G2</span> · <span class="story-title">Least-Privilege Analysis</span> <span class="wave-tag w1">W1</span></div>
+        <div><span class="story-id">G2</span> · <span class="story-title">最小權限分析</span> <span class="wave-tag w1">W1</span></div>
         <div class="story-criteria">
           <ul>
             <li>偵測 wildcard permissions、stale identities、unused permissions</li>
@@ -908,7 +903,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">G3</span> · <span class="story-title">Policy-as-Code Recommendation</span> <span class="wave-tag w3">W3</span></div>
+        <div><span class="story-id">G3</span> · <span class="story-title">Policy-as-Code 建議</span> <span class="wave-tag w3">W3</span></div>
         <div class="story-criteria">
           <ul>
             <li>支援 Terraform patch、OPA / Rego、Sentinel、Azure Policy、GCP Org Policy、AWS Config rule</li>
@@ -919,10 +914,10 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">H</span>Web-Based Desktop &amp; Mobile Experience <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
-      <p class="summary">Desktop Web 為完整工作台、Mobile Web 走 PWA 走伴隨介面；不做 native iOS / Android app。</p>
+      <h3><span class="pillar-id">H</span>Web 桌面與行動體驗 <span class="wave-tag w0">Wave 0</span> <span class="wave-tag w2">Wave 2</span></h3>
+      <p class="summary">Desktop Web 為完整工作台、Mobile Web 走 PWA 為伴隨介面；不做 native iOS / Android app。</p>
       <div class="story">
-        <div><span class="story-id">H1</span> · <span class="story-title">Desktop Web Full Workspace</span> <span class="wave-tag w0">W0</span></div>
+        <div><span class="story-id">H1</span> · <span class="story-title">桌面 Web 完整工作台</span> <span class="wave-tag w0">W0</span></div>
         <div class="story-criteria">
           <ul>
             <li>支援 AI Chat、draw.io editor、IaC editor、FinOps / Security / Ops dashboard、agent trace、approval mgmt console</li>
@@ -930,7 +925,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">H2</span> · <span class="story-title">Mobile Web Ops Companion</span> <span class="wave-tag w2">W2</span></div>
+        <div><span class="story-id">H2</span> · <span class="story-title">行動 Web 維運伴隨介面</span> <span class="wave-tag w2">W2</span></div>
         <div class="story-criteria">
           <ul>
             <li>Responsive web / PWA</li>
@@ -940,7 +935,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">H3</span> · <span class="story-title">Mobile Web Approval</span> <span class="wave-tag w2">W2</span></div>
+        <div><span class="story-id">H3</span> · <span class="story-title">行動 Web 審批（MFA / WebAuthn）</span> <span class="wave-tag w2">W2</span></div>
         <div class="story-criteria">
           <ul>
             <li>顯示 plan、affected resources、risk、impact、rollback</li>
@@ -952,7 +947,7 @@ flowchart LR
     </div>
 
     <div class="pillar">
-      <h3><span class="pillar-id">I</span>MCP &amp; Skill Management <span class="wave-tag w0">Wave 0</span></h3>
+      <h3><span class="pillar-id">I</span>MCP 與 Skill 管理 <span class="wave-tag w0">Wave 0</span></h3>
       <p class="summary">整個治理層的命脈：MCP server registry、skill catalog、權限／風險模型、approval workflow、observability。</p>
       <div class="story">
         <div><span class="story-id">I1</span> · <span class="story-title">MCP Server Registry</span></div>
@@ -975,7 +970,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">I3</span> · <span class="story-title">Tool Permission &amp; Risk Model</span></div>
+        <div><span class="story-id">I3</span> · <span class="story-title">Tool 權限與風險模型</span></div>
         <div class="story-criteria">
           <ul>
             <li>分類：read-only、write、deploy、delete、permission-change、production-impacting</li>
@@ -985,7 +980,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">I4</span> · <span class="story-title">MCP / Skill Approval Workflow</span></div>
+        <div><span class="story-id">I4</span> · <span class="story-title">MCP / Skill 審批流程</span></div>
         <div class="story-criteria">
           <ul>
             <li>新增高風險 tool、擴 auth scope、停用 critical tool 都要 review</li>
@@ -995,7 +990,7 @@ flowchart LR
         </div>
       </div>
       <div class="story">
-        <div><span class="story-id">I5</span> · <span class="story-title">Agent Tool Selection Observability</span></div>
+        <div><span class="story-id">I5</span> · <span class="story-title">Agent Tool 選用可觀察性</span></div>
         <div class="story-criteria">
           <ul>
             <li>顯示選用的 tool/skill、原因、input summary、permission level、approval status、execution result</li>
@@ -1008,15 +1003,10 @@ flowchart LR
   </section>
 
   <section id="nfr">
-    <h2>6. 非功能性需求 / NFR (cross-cutting)</h2>
-    <div class="bilingual">
-      <div class="lang-zh">
-        所有 wave 的 story 在 construction 階段都必須對齊以下 NFR；它們是 SRS §7 的 hard constraints。
-      </div>
-      <div class="lang-en">
-        Every wave's stories must align with these NFRs during construction; they are hard constraints from SRS §7.
-      </div>
-    </div>
+    <h2>6. 非功能性需求（NFR · cross-cutting）</h2>
+    <p style="color:var(--muted); font-size:0.92rem;">
+      所有 wave 的 story 在 construction 階段都必須對齊以下 NFR；它們是 SRS §7 的 hard constraints。
+    </p>
     <div class="nfr-grid" style="margin-top:0.8rem;">
       <div class="nfr-item">Security by default</div>
       <div class="nfr-item">Auditability（所有操作有 audit log）</div>
@@ -1034,7 +1024,7 @@ flowchart LR
   </section>
 
   <section id="risks">
-    <h2>7. 已知風險與待解 / Risks &amp; Open Questions</h2>
+    <h2>7. 已知風險與待解</h2>
     <ul class="risks">
       <li><b>Wave 0 太重</b>：MCP/Skill registry + Routing + Auth + Desktop shell 一次做太多。建議再細切成 W0a（registry + permission model + audit）／W0b（routing + chat shell）／W0c（desktop UI + auth）三個 sub-wave。</li>
       <li><b>Architecture Graph 設計</b>：A3 → C/D/E/G 都要吃 architecture graph。Schema 沒對齊就會回頭翻工。建議在 Wave 0 末或 Wave 1 起手就把 graph schema 先定下來（單獨 ADR）。</li>
@@ -1047,7 +1037,7 @@ flowchart LR
   </section>
 
   <section id="nextsteps">
-    <h2>8. 下一步 / Next Steps</h2>
+    <h2>8. 下一步</h2>
     <ol>
       <li><b>Workflow Planning（推薦下一步）</b>：以本計劃為輸入，跑 AIDLC <code>workflow-planning.md</code>，把每個 wave 拆成可執行的 unit / sprint。</li>
       <li><b>NFR 落地</b>：把 SRS §7 的 NFR 各自寫成可驗收條件，作為 construction 階段的 hard constraint。</li>
@@ -1060,14 +1050,17 @@ flowchart LR
 
   <footer>
     <p>
-      Generated 2026-05-09 · Source files:
-      <code>aidlc-docs/inception/requirements/cloud-360-srs.md</code>,
-      <code>aidlc-docs/inception/user-stories/core-pillars.md</code>,
-      <code>aidlc-docs/inception/application-design/system-architecture.md</code>.
+      建立 2026-05-09 · 更新 2026-05-10 · 來源檔案：
+      <code>aidlc-docs/inception/requirements/cloud-360-srs.md</code>、
+      <code>aidlc-docs/inception/user-stories/core-pillars.md</code>、
+      <code>aidlc-docs/inception/application-design/system-architecture.md</code>。
     </p>
     <p>
-      AIDLC v0.1.8 · Pre-enabled extensions: <code>security/baseline</code>, <code>testing/property-based</code>, <code>bilingual-docs</code>.
-      To open this file: <kbd>open aidlc-docs/inception/plans/development-plan.html</kbd>
+      AIDLC v0.1.8 · 預設啟用 extensions：<code>security/baseline</code>、<code>testing/property-based</code>、<code>bilingual-docs</code>。
+      開啟方式：<kbd>open aidlc-docs/inception/plans/development-plan.html</kbd>
+    </p>
+    <p>
+      Live 看板：<a href="https://github.com/users/opendiamonds/projects/16" target="_blank" rel="noopener noreferrer">opendiamonds/projects/16</a>（拖卡片改 Status / Wave）
     </p>
   </footer>
 

--- a/aidlc-docs/inception/plans/development-plan.html
+++ b/aidlc-docs/inception/plans/development-plan.html
@@ -197,6 +197,118 @@
     text-align: center;
   }
 
+  /* Kanban board */
+  .kanban {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(260px, 1fr));
+    gap: 0.9rem;
+    margin-top: 0.8rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+  @media (max-width: 1024px) {
+    .kanban {
+      grid-template-columns: repeat(4, minmax(260px, 320px));
+    }
+  }
+  .kanban-col {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 10px;
+    padding: 0.9rem 0.8rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  .kanban-col-header {
+    border-top: 4px solid var(--accent);
+    border-radius: 6px 6px 0 0;
+    padding: 0.6rem 0.65rem 0.7rem;
+    background: var(--card);
+    margin-bottom: 0.3rem;
+  }
+  .kanban-col.w0 .kanban-col-header { border-top-color: var(--w0); }
+  .kanban-col.w1 .kanban-col-header { border-top-color: var(--w1); }
+  .kanban-col.w2 .kanban-col-header { border-top-color: var(--w2); }
+  .kanban-col.w3 .kanban-col-header { border-top-color: var(--w3); }
+  .kanban-col-title {
+    font-weight: 700;
+    font-size: 0.95rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .kanban-col-meta {
+    color: var(--muted);
+    font-size: 0.78rem;
+    margin-top: 0.25rem;
+  }
+  .kanban-card {
+    background: var(--card);
+    border-radius: 6px;
+    padding: 0.65rem 0.75rem;
+    border-left: 3px solid var(--accent);
+    cursor: default;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+  }
+  .kanban-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  }
+  .kanban-col.w0 .kanban-card { border-left-color: var(--w0); }
+  .kanban-col.w1 .kanban-card { border-left-color: var(--w1); }
+  .kanban-col.w2 .kanban-card { border-left-color: var(--w2); }
+  .kanban-col.w3 .kanban-card { border-left-color: var(--w3); }
+  .kanban-card-id {
+    font-weight: 700;
+    color: var(--accent2);
+    font-size: 0.78rem;
+    letter-spacing: 0.4px;
+  }
+  .kanban-card-title {
+    font-weight: 600;
+    font-size: 0.88rem;
+    margin: 0.2rem 0 0.3rem;
+    line-height: 1.35;
+  }
+  .kanban-card-pillar {
+    display: inline-block;
+    background: rgba(56, 189, 248, 0.12);
+    color: var(--accent);
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-right: 0.3rem;
+  }
+  .kanban-card-deps {
+    color: var(--muted);
+    font-size: 0.74rem;
+    margin-top: 0.35rem;
+  }
+  .kanban-legend {
+    display: flex;
+    gap: 1.2rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.8rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+  .kanban-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .kanban-legend-dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    display: inline-block;
+  }
+  .kanban-legend-dot.w0 { background: var(--w0); }
+  .kanban-legend-dot.w1 { background: var(--w1); }
+  .kanban-legend-dot.w2 { background: var(--w2); }
+  .kanban-legend-dot.w3 { background: var(--w3); }
+
   .bilingual {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -278,14 +390,22 @@
     <h1>Cloud-360 開發計劃 / Development Plan</h1>
     <div class="subtitle">9 Pillars · 26 User Stories · 4 Waves · AIDLC v0.1.8 inception artifact</div>
     <div class="meta-row">
-      Generated 2026-05-09 · Source: <code>aidlc-docs/inception/{requirements,user-stories,application-design}/</code> · Status: Draft
+      Generated 2026-05-09 · Updated 2026-05-10 · Source: <code>aidlc-docs/inception/{requirements,user-stories,application-design}/</code> · Status: Draft
+    </div>
+    <div style="margin-top:0.9rem;">
+      <a href="https://github.com/users/Dannielchung/projects/1"
+         target="_blank" rel="noopener noreferrer"
+         style="display:inline-flex; align-items:center; gap:0.5rem; padding:0.55rem 1rem; background:linear-gradient(90deg,var(--accent),var(--accent2)); color:#0f172a; font-weight:700; text-decoration:none; border-radius:6px; font-size:0.9rem;">
+        ▶ View on GitHub Project (live kanban)
+      </a>
+      <span style="color:var(--muted); font-size:0.82rem; margin-left:0.7rem;">本 HTML 是靜態快照；GitHub Project 是 live 看板，可拖卡片改 status</span>
     </div>
   </header>
 
   <nav class="toc">
     <strong>目錄</strong>
     <a href="#summary">總覽</a>
-    <a href="#waves">4 個 Wave</a>
+    <a href="#kanban">Kanban 看板</a>
     <a href="#dep-graph">相依圖</a>
     <a href="#story-table">26 條 Stories</a>
     <a href="#pillars">9 個 Pillar 細節</a>
@@ -315,81 +435,209 @@
     </div>
   </section>
 
-  <section id="waves">
-    <h2>2. 4 個 Wave / Delivery Waves</h2>
+  <section id="kanban">
+    <h2>2. Kanban 看板 / Wave-based Kanban</h2>
+    <p style="color:var(--muted); font-size:0.92rem;">
+      四欄看板對應 4 個 delivery wave；卡片左邊色條同 wave。<a href="https://github.com/users/Dannielchung/projects/1" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">在 GitHub Project 上拖卡片可改 Status / Wave</a>，本 HTML 是靜態快照。
+    </p>
 
-    <div class="wave w0">
-      <h3>Wave 0 <span class="wave-tag w0">Foundation</span></h3>
-      <div class="goal">先做基礎設施才會有東西可裝。<br><span style="color:var(--muted)">Build the foundation that everything else relies on.</span></div>
-      <div class="meta">
-        <span><b>Stories:</b> 8</span>
-        <span><b>Deps:</b> none</span>
-        <span><b>Theme:</b> Registry · Routing · Auth · Shell</span>
-      </div>
-      <div class="stories">
-        <span class="story-chip"><span class="id">I1</span>MCP Server Registry</span>
-        <span class="story-chip"><span class="id">I2</span>Skill Catalog</span>
-        <span class="story-chip"><span class="id">I3</span>Tool Permission/Risk Model</span>
-        <span class="story-chip"><span class="id">I4</span>MCP/Skill Approval Workflow</span>
-        <span class="story-chip"><span class="id">I5</span>Agent Tool Selection Observability</span>
-        <span class="story-chip"><span class="id">F1</span>AI Chat Cloud Query (read-only)</span>
-        <span class="story-chip"><span class="id">F2</span>AI Chat Cloud Operation (with approval)</span>
-        <span class="story-chip"><span class="id">H1</span>Desktop Web Full Workspace shell</span>
-      </div>
+    <div class="kanban-legend">
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w0"></span>W0 Foundation · 8 stories · no deps</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w1"></span>W1 Core · 9 stories · ← W0</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w2"></span>W2 FinOps/Ops/Mobile · 8 stories · ← W1</span>
+      <span class="kanban-legend-item"><span class="kanban-legend-dot w3"></span>W3 Extensions · 1 story · ← W1</span>
     </div>
 
-    <div class="wave w1">
-      <h3>Wave 1 <span class="wave-tag w1">Core Differentiators</span></h3>
-      <div class="goal">使用者最有感的入口：自然語言設計 + 共編 draw.io、選型與 IaC、安全檢視。<br><span style="color:var(--muted)">The signature capabilities users come for.</span></div>
-      <div class="meta">
-        <span><b>Stories:</b> 9</span>
-        <span><b>Deps:</b> Wave 0</span>
-        <span><b>Theme:</b> Architecture · Selection · IaC · Security</span>
-      </div>
-      <div class="stories">
-        <span class="story-chip"><span class="id">A1</span>Natural Language → Architecture</span>
-        <span class="story-chip"><span class="id">A2</span>Well-Architected Review</span>
-        <span class="story-chip"><span class="id">A3</span>AI + draw.io Co-editing</span>
-        <span class="story-chip"><span class="id">B1</span>Service Comparison Matrix</span>
-        <span class="story-chip"><span class="id">B2</span>Workload-Based Recommendation</span>
-        <span class="story-chip"><span class="id">D1</span>Modular IaC Generation</span>
-        <span class="story-chip"><span class="id">D2</span>IaC Security Scan</span>
-        <span class="story-chip"><span class="id">G1</span>Multi-Cloud Security Review</span>
-        <span class="story-chip"><span class="id">G2</span>Least-Privilege Analysis</span>
-      </div>
-    </div>
+    <div class="kanban">
 
-    <div class="wave w2">
-      <h3>Wave 2 <span class="wave-tag w2">FinOps · Ops · Mobile</span></h3>
-      <div class="goal">把 architecture graph 餵給 FinOps / Ops，把 Mobile Web approval 補齊。<br><span style="color:var(--muted)">Cost insights, ops optimization, and mobile companion.</span></div>
-      <div class="meta">
-        <span><b>Stories:</b> 8</span>
-        <span><b>Deps:</b> Wave 1（FinOps/Ops 需要 architecture graph）</span>
-        <span><b>Theme:</b> Cost · Ops · Mobile · Agentic</span>
+      <!-- W0 -->
+      <div class="kanban-col w0">
+        <div class="kanban-col-header">
+          <div class="kanban-col-title">Wave 0 — Foundation <span class="wave-tag w0">8</span></div>
+          <div class="kanban-col-meta">Registry · Routing · Auth · Shell · no deps</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">I1</div>
+          <div class="kanban-card-title">MCP Server Registry</div>
+          <span class="kanban-card-pillar">I MCP/Skill</span>
+          <div class="kanban-card-deps">Deps: foundation</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">I2</div>
+          <div class="kanban-card-title">Skill Catalog</div>
+          <span class="kanban-card-pillar">I MCP/Skill</span>
+          <div class="kanban-card-deps">Deps: I1</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">I3</div>
+          <div class="kanban-card-title">Tool Permission &amp; Risk Model</div>
+          <span class="kanban-card-pillar">I MCP/Skill</span>
+          <div class="kanban-card-deps">Deps: I1, I2</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">I4</div>
+          <div class="kanban-card-title">MCP / Skill Approval Workflow</div>
+          <span class="kanban-card-pillar">I MCP/Skill</span>
+          <div class="kanban-card-deps">Deps: I1–I3, Audit</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">I5</div>
+          <div class="kanban-card-title">Agent Tool Selection Observability</div>
+          <span class="kanban-card-pillar">I MCP/Skill</span>
+          <div class="kanban-card-deps">Deps: I1–I4, Routing trace</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">F1</div>
+          <div class="kanban-card-title">AI Chat Cloud Query (read-only)</div>
+          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
+          <div class="kanban-card-deps">Deps: I1, Agent Routing</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">F2</div>
+          <div class="kanban-card-title">AI Chat Cloud Operation (with approval)</div>
+          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
+          <div class="kanban-card-deps">Deps: F1, Approval Gate, I3</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">H1</div>
+          <div class="kanban-card-title">Desktop Web Full Workspace</div>
+          <span class="kanban-card-pillar">H Web UX</span>
+          <div class="kanban-card-deps">Deps: API GW, Auth/MFA/WebAuthn</div>
+        </div>
       </div>
-      <div class="stories">
-        <span class="story-chip"><span class="id">C1</span>Monthly TCO Estimation</span>
-        <span class="story-chip"><span class="id">C2</span>Spot/Preemptible Comparison</span>
-        <span class="story-chip"><span class="id">C3</span>Cross-Cloud Egress Analysis</span>
-        <span class="story-chip"><span class="id">E1</span>Right-sizing Recommendation</span>
-        <span class="story-chip"><span class="id">E2</span>Architecture Modernization</span>
-        <span class="story-chip"><span class="id">F3</span>Agentic AI Operations</span>
-        <span class="story-chip"><span class="id">H2</span>Mobile Web Ops Companion</span>
-        <span class="story-chip"><span class="id">H3</span>Mobile Web Approval (MFA/WebAuthn)</span>
-      </div>
-    </div>
 
-    <div class="wave w3">
-      <h3>Wave 3 <span class="wave-tag w3">Extensions / Governance Depth</span></h3>
-      <div class="goal">Policy-as-Code 自動產生、深層 audit 與可重用治理規則。<br><span style="color:var(--muted)">Policy-as-Code automation and deeper governance.</span></div>
-      <div class="meta">
-        <span><b>Stories:</b> 1</span>
-        <span><b>Deps:</b> Wave 1（G1/G2 finding stream）</span>
-        <span><b>Theme:</b> Policy-as-Code</span>
+      <!-- W1 -->
+      <div class="kanban-col w1">
+        <div class="kanban-col-header">
+          <div class="kanban-col-title">Wave 1 — Core <span class="wave-tag w1">9</span></div>
+          <div class="kanban-col-meta">Architecture · Selection · IaC · Security · ← W0</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">A1</div>
+          <div class="kanban-card-title">Natural Language → Architecture</div>
+          <span class="kanban-card-pillar">A Architecture</span>
+          <div class="kanban-card-deps">Deps: Routing (W0), Intent Parser, Design Agent</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">A2</div>
+          <div class="kanban-card-title">Well-Architected Review</div>
+          <span class="kanban-card-pillar">A Architecture</span>
+          <div class="kanban-card-deps">Deps: A1, provider best-practice rules</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">A3</div>
+          <div class="kanban-card-title">AI + draw.io Co-editing</div>
+          <span class="kanban-card-pillar">A Architecture</span>
+          <div class="kanban-card-deps">Deps: draw.io XML adapter → Architecture Graph</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">B1</div>
+          <div class="kanban-card-title">Service Comparison Matrix</div>
+          <span class="kanban-card-pillar">B Cross-Cloud</span>
+          <div class="kanban-card-deps">Deps: cloud catalog data</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">B2</div>
+          <div class="kanban-card-title">Workload-Based Recommendation</div>
+          <span class="kanban-card-pillar">B Cross-Cloud</span>
+          <div class="kanban-card-deps">Deps: B1 + Component Selection Agent</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">D1</div>
+          <div class="kanban-card-title">Modular IaC Generation</div>
+          <span class="kanban-card-pillar">D IaC</span>
+          <div class="kanban-card-deps">Deps: Architecture Graph, provider templates</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">D2</div>
+          <div class="kanban-card-title">IaC Security Scan</div>
+          <span class="kanban-card-pillar">D IaC</span>
+          <div class="kanban-card-deps">Deps: D1, tfsec/trivy/Checkov MCP</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">G1</div>
+          <div class="kanban-card-title">Multi-Cloud Security Review</div>
+          <span class="kanban-card-pillar">G Security</span>
+          <div class="kanban-card-deps">Deps: IAM/Config/SCC/Defender MCP</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">G2</div>
+          <div class="kanban-card-title">Least-Privilege Analysis</div>
+          <span class="kanban-card-pillar">G Security</span>
+          <div class="kanban-card-deps">Deps: G1 + IAM Access Analyzer-style data</div>
+        </div>
       </div>
-      <div class="stories">
-        <span class="story-chip"><span class="id">G3</span>Policy-as-Code Recommendation (OPA / Sentinel / Azure Policy / GCP Org Policy / AWS Config rule)</span>
+
+      <!-- W2 -->
+      <div class="kanban-col w2">
+        <div class="kanban-col-header">
+          <div class="kanban-col-title">Wave 2 — FinOps · Ops · Mobile <span class="wave-tag w2">8</span></div>
+          <div class="kanban-col-meta">Cost · Ops · Mobile · Agentic · ← W1</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">C1</div>
+          <div class="kanban-card-title">Monthly TCO Estimation</div>
+          <span class="kanban-card-pillar">C FinOps</span>
+          <div class="kanban-card-deps">Deps: Architecture Graph, pricing API</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">C2</div>
+          <div class="kanban-card-title">Spot / Preemptible Comparison</div>
+          <span class="kanban-card-pillar">C FinOps</span>
+          <div class="kanban-card-deps">Deps: C1 base pricing</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">C3</div>
+          <div class="kanban-card-title">Cross-Cloud Egress Analysis</div>
+          <span class="kanban-card-pillar">C FinOps</span>
+          <div class="kanban-card-deps">Deps: Architecture Graph traffic edges</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">E1</div>
+          <div class="kanban-card-title">Right-sizing Recommendation</div>
+          <span class="kanban-card-pillar">E Operations</span>
+          <div class="kanban-card-deps">Deps: cloud metrics MCP, Approval Gate</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">E2</div>
+          <div class="kanban-card-title">Architecture Modernization</div>
+          <span class="kanban-card-pillar">E Operations</span>
+          <div class="kanban-card-deps">Deps: Architecture Graph + new-service catalog</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">F3</div>
+          <div class="kanban-card-title">Agentic AI Operations</div>
+          <span class="kanban-card-pillar">F AI Multi-Cloud</span>
+          <div class="kanban-card-deps">Deps: provider signal pipelines + Memory + Routing</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">H2</div>
+          <div class="kanban-card-title">Mobile Web Ops Companion</div>
+          <span class="kanban-card-pillar">H Web UX</span>
+          <div class="kanban-card-deps">Deps: responsive shell, F1/F3 outputs</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">H3</div>
+          <div class="kanban-card-title">Mobile Web Approval (MFA/WebAuthn)</div>
+          <span class="kanban-card-pillar">H Web UX</span>
+          <div class="kanban-card-deps">Deps: H2 + WebAuthn / Passkey</div>
+        </div>
       </div>
+
+      <!-- W3 -->
+      <div class="kanban-col w3">
+        <div class="kanban-col-header">
+          <div class="kanban-col-title">Wave 3 — Extensions <span class="wave-tag w3">1</span></div>
+          <div class="kanban-col-meta">Policy-as-Code · ← W1</div>
+        </div>
+        <div class="kanban-card">
+          <div class="kanban-card-id">G3</div>
+          <div class="kanban-card-title">Policy-as-Code Recommendation</div>
+          <span class="kanban-card-pillar">G Security</span>
+          <div class="kanban-card-deps">Deps: G1+G2 findings, Approval Gate. Targets: OPA/Rego, Sentinel, Azure Policy, GCP Org Policy, AWS Config rule</div>
+        </div>
+      </div>
+
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

Translate Cloud-360's 9 pillars and 26 user stories from \`aidlc-docs/inception/{requirements,user-stories}/\` into an executable delivery plan. Output is a single HTML file you can open straight in a browser.

> 📂 Open: \`open aidlc-docs/inception/plans/development-plan.html\`

## What's in the plan

- **Overview** with stat cards (9 pillars · 26 stories · 4 waves · 3 cloud providers)
- **4 delivery waves** with bilingual goals, story chips, and meta:
  - **W0 Foundation** — I1-I5 (MCP/Skill mgmt), F1-F2 (Chat), H1 (Desktop shell) + Auth/RBAC/MFA/WebAuthn
  - **W1 Core Differentiators** — A1-A3 (Design), B1-B2 (Selection), D1-D2 (IaC), G1-G2 (Security)
  - **W2 FinOps · Ops · Mobile** — C1-C3 (FinOps), E1-E2 (Ops), F3 (Agentic), H2-H3 (Mobile)
  - **W3 Extensions** — G3 (Policy-as-Code)
- **Mermaid dependency graph** (W0 → W1 → W2/W3) loaded via CDN with dark theme
- **26-row story table** with Pillar / Wave tag / Key dependencies
- **9 pillar detail cards** including each story's acceptance criteria
- **NFR grid** (12 cross-cutting constraints from SRS §7 + repo overrides)
- **Risks &amp; open questions** (W0 size, Architecture Graph schema, pricing freshness, IAM abstraction, approval payload, agentic-AI side effects, property-based test scope)
- **Next steps** (Workflow Planning, NFR concretization, W0 sub-split, Architecture Graph ADR, reverse-engineering, start Pillar I)

## Files

| File | Purpose |
|---|---|
| \`aidlc-docs/inception/plans/development-plan.html\` | The plan itself (~840 lines, self-contained HTML + inline CSS) |
| \`aidlc-docs/inception/plans/README.md\` | Bilingual directory index |
| \`aidlc-docs/audit.md\` | Bilingual PR #18 entry |

## Test plan

- [x] \`python scripts/validate_repo_contract.py\` passes locally
- [ ] CI green
- [ ] Open \`development-plan.html\` in Chrome / Safari — Mermaid graph renders, dark theme works, all sections scroll-anchored from the TOC
- [ ] Mobile view (responsive) — bilingual side-by-side becomes single column under 768px
- [ ] Print preview produces a readable B&amp;W version (the print stylesheet is included)
- [ ] Reviewer skim of pillar detail cards — every story's acceptance criteria match \`core-pillars.md\`
- [ ] No changes to upstream \`.aidlc-rule-details/\`; source SRS / user-stories untouched

## Out of scope

- This is a **read-only summary** of existing requirements. No new pillars, no new stories, no scope changes.
- Concrete sprint scheduling and team assignment are deferred to the next AIDLC \`workflow-planning\` stage.
- The W0 sub-split (W0a/W0b/W0c) suggested in the Risks section is a recommendation, not a commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)