### PR TITLE
文件(ops): 補上 staging 中斷事件記錄與 Slack 告警決定

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -286,3 +286,32 @@
 
 **仍未驗證**：`needs.deploy.outputs.*` / `needs.rollback.outputs.*` 的 job outputs 串接，只有真實部署會行經該路徑。
 **Approver**: danniel
+
+---
+
+#### 2026-07-26 13:10 +08:00 — Staging 中斷：Error 1033（runner 離線）
+
+**User request (raw)**: "目前環境掛掉了，代表ut有異常"
+**Stage**: Operations → Incident Response
+**症狀**: `https://cloud360.danniel.cc/` 回 Cloudflare `Error 1033 Cloudflare Tunnel error`（Ray ID `a213a5c38f30ce41`）。
+
+**根因**: **不是 `ut` 的程式碼異常**。self-hosted runner `cloud360-10-10`（即 192.168.10.10）離線；該機同時承載應用容器與 `cloudflared` 容器，機器層失效導致 tunnel 斷線，Cloudflare 找不到出口而回 1033。
+
+**判斷依據**: deploy job 呈 `queued`／`pending` 而非 `failure` — 代表 job 從未被領走執行，而非執行後失敗。若為程式碼問題，deploy 會執行並失敗，並觸發 rollback 與 Deploy Doctor。GitHub API 查得 runner `status=offline` 佐證。
+
+**時間軸**:
+| 時間 | 事件 |
+|---|---|
+| 07-19 06:34 | 最後一次成功部署（`ea5d6b1d`） |
+| 07-25 18:08 | deploy 觸發（`2f0da31b`），卡在 queued |
+| 07-26 08:05 | deploy 被 cancelled（`03887005`） |
+| 07-26 09:08 | deploy 觸發（`0cae22ed`），卡在 pending |
+| 07-26 13:10 | 使用者回報 Error 1033 |
+
+**處置**: 依 `operations/runbooks.md` Playbook F（Self-hosted runner 離線）重啟 runner service。
+
+**結果**: runner 回到 `online`；兩個積壓 job 依時間序執行並全部 success（`2f0da31b` → `0cae22ed`，最新版最後落地）；`https://cloud360.danniel.cc/` 回 HTTP 200。附帶效果為 `ut` 自 07-19 起累積的 A3 Well-Architected 與 A1 chat UX 變更一併部署至 staging，**尚待手動驗收**。
+
+**暴露的缺口（未處理）**: 本次無任何自動告警。兩層原因：(1) Slack 通知目前只在 `main`，尚未同步至 `ut`；(2) 即使同步，`notify` job 掛在 `deploy` 之後，job 卡在 queued 時不會執行。現行設計能回報「部署失敗」，無法回報「部署未開始」或「站台不可用」。補法必須是**外部**健康檢查告警（例如 dc-infra 的 Prometheus blackbox 探測 `cloud360.danniel.cc`），機器自身失效時無法由其自行發出警報。對應 `runbooks.md` 第 4 章「告警去向」的待補項。
+
+**Approver**: danniel

--- a/aidlc-docs/operations/runbooks.md
+++ b/aidlc-docs/operations/runbooks.md
@@ -106,6 +106,16 @@
 - **症狀**：部署/build 失敗於 no space。10.10 跑多個服務。
 - **處置**：`docker system df` 看用量 →  `docker image prune -f` / `docker builder prune -f`（勿 `-a --volumes`，會誤刪其他服務資料）。
 
-### 4. 告警去向（待補）
+### 4. 告警去向
 
-主動告警（服務掛掉、部署失敗、憑證問題）目前靠人看。決定 observability 工具後，告警優先送 Telegram（Dan ↔ Claude Code 頻道），此節補上實際路由。
+**一律送 Slack `#nemoclaw`**（channel ID `C0B5XEQDVR7`，bot `NeMoClaw`）。取代原先「優先送 Telegram」的規劃，理由是部署通知已於 2026-07-25 落地於同一頻道，告警與部署事件集中在同一處才看得到完整時序。
+
+| 告警來源 | 現況 | 觸發條件 |
+|---|---|---|
+| 部署成功／失敗／回滾 | ✅ 已上線（`deploy.yml` 的 `notify` job） | deploy job 實際執行後 |
+| 站台可用性 | ⏳ 待建（見 issue #467） | 外部 blackbox 探測連續失敗 |
+| Self-hosted runner 離線 | ⏳ 待建（見 issue #467） | runner `status=offline` |
+
+**關鍵限制**：`notify` job 掛在 `deploy` 之後，job 卡在 `queued`（runner 離線）時整條 workflow 不執行，因此**無法**回報「部署未開始」或「站台不可用」。這兩類必須由 192.168.10.10 **之外**的探測發出 —— 該機失效時發不出自己失效的警報（2026-07-26 事件已驗證，見 `audit.md`）。
+
+站台可用性與 runner 探測實作於 dc-infra repo（見 ADR-0007 的 repo 邊界）。


### PR DESCRIPTION
## 內容

補進 PR #421 合併後才產生的兩筆 Operations 文件，`main` 目前缺少：

| Commit | 內容 |
|---|---|
| `1a684bb` | `audit.md` 記錄 2026-07-26 staging 中斷事件（Cloudflare Error 1033 / runner 離線） |
| `42faf64` | `runbooks.md` 第 4 章「告警去向」從「待補」更新為 Slack `#nemoclaw` |

僅文件變更，無程式碼異動。

## 補充

這兩筆已透過 `ut` 的合併（`5951541`）進入 `ut`，本 PR 讓 `main` 同步，避免刪除來源分支後 `main` 要等下次 `ut` → `main` 同步才拿得到。

事件記錄特別寫下判斷依據（deploy job 呈 `queued` 而非 `failure`，代表 job 從未被領走 → 是機器層而非程式碼問題），供下次遇到同類症狀時快速定位。

runbook 除了記下 Slack 決定，也補上現行設計的限制：`notify` job 掛在 `deploy` 之後，job 卡在 queued 時不會執行，因此無法回報「部署未開始」或「站台不可用」——那兩類需外部健康檢查，追蹤於 #467。