### PR TITLE
功能(llm): 新增 LLM_PROVIDER，本機可改用已登入的 claude CLI

### DIFF
--- a/LOCAL-DEV.md
+++ b/LOCAL-DEV.md
@@ -14,23 +14,38 @@
 | 登入／RBAC／使用者管理（J1、J3a、J3b） | **只要 PostgreSQL** | — |
 | 架構圖 CRUD／分享（A2、A4） | 只要 PostgreSQL | — |
 | Well-Architected 離線規則打分（A3 的規則層） | 只要 PostgreSQL | — |
-| **A1 對話產圖** | PostgreSQL ＋ **Node ＋ Claude Code CLI** ＋ **OpenRouter 金鑰** | API 回 **500** |
+| **A1 對話產圖** | PostgreSQL ＋ **一個能認證的 LLM 供應商**（見下方 H1） | API 回 **500** |
 | **A3 改善建議** | 同上 | 建議階段降級為 `rules_only` |
 | **A3「優化」（Design↔Review 協作）** | 同上 | 失敗 |
-| **Offline Lens agent 填答** | 同上 | 失敗 |
+| **Offline Lens agent 填答** | 同上 | 降級為規則啟發式（會寫 WARNING log） |
 | 動態 SVG 圖示 | n8n webhook（**選填**） | 用灰底 fallback 圖示，不中斷 |
 
 ### 兩個「不在 requirements.txt 裡」的硬依賴
 
-**H1 — Claude Code CLI**：`claude-agent-sdk` 不是 HTTP client，它會 **spawn 一個 `claude` CLI 子行程**。所以主機上必須有 Node 與全域安裝的 `@anthropic-ai/claude-code`。這件事只寫在 `backend/Dockerfile` 與 `DEPLOY.md` §0 —— 一個「只看 requirements.txt 就以為能跑」的 venv，會在你按下 A1 產圖時才失敗，而且錯誤訊息未必指向缺少 CLI。
-
-**LLM 鏈路長這樣**（不是直連 Anthropic）：
+**H1 — LLM 供應商**：`claude-agent-sdk` 不是 HTTP client，它會 **spawn 一個 `claude` CLI 子行程**。鏈路長這樣：
 
 ```
-FastAPI → claude-agent-sdk → claude CLI 子行程 → OpenRouter → 模型
+FastAPI → claude-agent-sdk → claude CLI 子行程 → 供應商 → 模型
 ```
 
-`OPENROUTER_API_KEY` 在啟動時被 `configure_openrouter_env()` 映射為 `ANTHROPIC_AUTH_TOKEN`。**`ANTHROPIC_API_KEY` 必須留空**，否則 SDK 會繞過 OpenRouter 直連 Anthropic。
+供應商由 `LLM_PROVIDER` 決定（`backend/services/llm_provider.py`），本機有兩條路：
+
+| `LLM_PROVIDER` | 認證來源 | 適用 |
+|---|---|---|
+| `cli`（本機範本的預設） | 你自己 `claude login` 的登入（macOS 存在 Keychain） | 本機。不需金鑰、不燒 OpenRouter 額度 |
+| `openrouter`（程式預設、部署用） | `OPENROUTER_API_KEY` | 部署；本機想用 OpenRouter 時也可 |
+
+`cli` 模式需要**登入過**的 CLI。SDK 自帶一份 `claude` 執行檔（`claude_agent_sdk/_bundled/claude`），所以不一定要全域安裝 `@anthropic-ai/claude-code`——但**登入不是自帶的**，你得先在終端機跑過 `claude login`（或已在用 Claude Code）。驗證：
+
+```bash
+claude -p "回一個字：好"      # 有回應 = 登入可用
+```
+
+`cli` 模式下程式會**主動刪除** `ANTHROPIC_BASE_URL`／`ANTHROPIC_AUTH_TOKEN`／`ANTHROPIC_API_KEY`。這不是潔癖：這三個只要**非空**就會蓋掉 CLI 自己的登入（前兩者還會讓請求被導去別的端點），而 `.env` 是以 `override=True` 載入的，所以磁碟上或 shell 裡的殘值都會傳進子行程。設成空字串不夠，必須刪掉。
+
+`openrouter` 模式下，`OPENROUTER_API_KEY` 會在啟動時被映射為 `ANTHROPIC_AUTH_TOKEN`，且 `ANTHROPIC_API_KEY` 必須留空，否則 SDK 會繞過 OpenRouter 直連 Anthropic。
+
+> ⚠️ **金鑰欄位留空就是留空，不要填佔位字串。** 程式判斷「有沒有設定」看的是非空，所以 `OPENROUTER_API_KEY=your_openrouter_api_key_here` 會被當成真金鑰送出去，換來一個離肇因三層遠的 401。範本現在一律出空值、範例寫在註解裡，`scripts/validate_env_contract.py` 也會擋下佔位值。
 
 ---
 
@@ -112,12 +127,15 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cloud360
 JWT_SECRET=dev_only_change_me
 CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
-# --- 以下只有 A1／A3／優化 需要 ---
-OPENROUTER_API_KEY=sk-or-v1-...        # 你自己的金鑰
-ANTHROPIC_BASE_URL=https://openrouter.ai/api
-ANTHROPIC_API_KEY=                     # 必須留空
-LLM_MODEL=anthropic/claude-sonnet-4.6
-LLM_MAX_OUTPUT_TOKENS=12000
+# LLM 供應商：cli 用你已登入的 claude CLI，不需任何金鑰（見第 0 節 H1）
+LLM_PROVIDER=cli
+
+# 只有 LLM_PROVIDER=openrouter 時才需要。留空＝未設定；
+# 千萬不要填佔位字串，那會被當成真金鑰送出去。
+OPENROUTER_API_KEY=
+
+# 留空即依供應商取預設（cli → sonnet）
+LLM_MODEL=
 
 # --- 選填 ---
 # N8N_WEBHOOK_URL=https://.../webhook/get-icon
@@ -126,9 +144,12 @@ LLM_MAX_OUTPUT_TOKENS=12000
 EOF
 ```
 
+> `JWT_SECRET` 未設時會**靜默 fallback 到程式碼內的預設字串**（依賴風險 R2），不會報錯。本機無所謂，但要知道它不會提醒你。
+
+要改用 OpenRouter 的話，把 `LLM_PROVIDER` 改成 `openrouter` 並填入 `OPENROUTER_API_KEY` 即可，其餘不用動——`ANTHROPIC_*` 三個變數由程式依模式自動處理。
+
 > **本機設定與部署設定是分開的兩套，不要互相抄。** `backend/.env`／`frontend/.env` 只服務本機 bare-metal 執行；部署走 `deploy/.env`（由 `deploy/render-env.sh` 產生，範本 `deploy/.env.example`）。把 `localhost` 來源寫進部署範本、或把 `POSTGRES_*`／`PUBLIC_URL` 寫進本機範本，`scripts/validate_env_contract.py` 都會擋下（CI 紅燈）。
 
-> `JWT_SECRET` 未設時會**靜默 fallback 到程式碼內的預設字串**（依賴風險 R2），不會報錯。本機無所謂，但要知道它不會提醒你。
 
 > **金鑰安全**：`.env` 已被 `.gitignore` 涵蓋（`.gitignore:17`），可以安心放 `OPENROUTER_API_KEY`。但要知道**這是唯一的防線** —— `validate_repo_contract.py` 的 secret 掃描只讀 contract 清單內的檔案，**看不到 `backend/`／`frontend/`**（`team.md` 已記為既有機制落差）。所以金鑰**絕不要**寫進 `.env` 以外的地方，例如貼進程式碼、測試或文件。
 

--- a/LOCAL-DEV.md
+++ b/LOCAL-DEV.md
@@ -18,7 +18,7 @@
 | **A3 改善建議** | 同上 | 建議階段降級為 `rules_only` |
 | **A3「優化」（Design↔Review 協作）** | 同上 | 失敗 |
 | **Offline Lens agent 填答** | 同上 | 降級為規則啟發式（會寫 WARNING log） |
-| 動態 SVG 圖示 | n8n webhook（**選填**） | 用灰底 fallback 圖示，不中斷 |
+| 動態 SVG 圖示 | n8n webhook（**選填**，見下方「圖示目錄」） | 用灰底 fallback 圖示，不中斷 |
 
 ### 兩個「不在 requirements.txt 裡」的硬依賴
 
@@ -52,7 +52,16 @@ claude -p "回一個字：好"      # 有回應 = 登入可用
 
 `openrouter` 模式下，`OPENROUTER_API_KEY` 會在啟動時被映射為 `ANTHROPIC_AUTH_TOKEN`，且 `ANTHROPIC_API_KEY` 必須留空，否則 SDK 會繞過 OpenRouter 直連 Anthropic。
 
-> ⚠️ **金鑰欄位留空就是留空，不要填佔位字串。** 程式判斷「有沒有設定」看的是非空，所以 `OPENROUTER_API_KEY=your_openrouter_api_key_here` 會被當成真金鑰送出去，換來一個離肇因三層遠的 401。範本現在一律出空值、範例寫在註解裡，`scripts/validate_env_contract.py` 也會擋下佔位值。
+> ⚠️ **金鑰欄位留空就是留空，不要填佔位字串。** 程式判斷「有沒有設定」看的是非空，所以 `OPENROUTER_API_KEY=your_openrouter_api_key_here` 會被當成真金鑰送出去，換來一個離肇因三層遠的 401。範本現在一律出空值、範例寫在註解裡，`scripts/validate_env_contract.py` 也會擋下佔位值。同一個陷阱也適用 `N8N_WEBHOOK_URL`：留著 `your_n8n_webhook_url_here` 會讓每個節點發一次必然失敗的請求，圖照樣出來、但圖示全是灰底。
+
+### 圖示目錄
+
+`N8N_WEBHOOK_URL` 那支 webhook 回傳的是**整份目錄**（一次約 1.1 MB），由後端自己在裡面比對服務名稱。兩件事值得先知道：
+
+- **目錄目前只收 AWS**（315 項）。GCP／Azure 的服務一定比對不到，圖示會是灰底 —— 這是預期行為，不是壞掉。
+- **目錄用服務全名，架構圖用縮寫**。`SNS` 在目錄裡叫 `Simple Notification Service`，兩者沒有共同子字串。後端有一份對照表處理常見縮寫（S3、SNS、SQS、SES、KMS、ELB、MSK、IAM、ECS、EKS、ECR、VPC、CDN、ASG）；表以外的縮寫比對不到就落到灰底，並寫一行 WARNING。
+
+比對不到時**一律**回灰底佔位圖，不會退而求其次給一個相近的圖示 —— 錯的圖示比灰底更難發現。
 
 ---
 

--- a/LOCAL-DEV.md
+++ b/LOCAL-DEV.md
@@ -41,7 +41,14 @@ FastAPI → claude-agent-sdk → claude CLI 子行程 → 供應商 → 模型
 claude -p "回一個字：好"      # 有回應 = 登入可用
 ```
 
-`cli` 模式下程式會**主動刪除** `ANTHROPIC_BASE_URL`／`ANTHROPIC_AUTH_TOKEN`／`ANTHROPIC_API_KEY`。這不是潔癖：這三個只要**非空**就會蓋掉 CLI 自己的登入（前兩者還會讓請求被導去別的端點），而 `.env` 是以 `override=True` 載入的，所以磁碟上或 shell 裡的殘值都會傳進子行程。設成空字串不夠，必須刪掉。
+`cli` 模式下程式會**主動刪除**兩組變數。這不是潔癖：`.env` 是以 `override=True` 載入的，磁碟上或 shell 裡的殘值都會傳進子行程，而設成空字串不夠，必須刪掉。
+
+| 被刪除的變數 | 留著會怎樣 |
+|---|---|
+| `ANTHROPIC_BASE_URL`／`ANTHROPIC_AUTH_TOKEN`／`ANTHROPIC_API_KEY` | 只要**非空**就會蓋掉 CLI 自己的登入；前兩者還會讓請求被導去別的端點 |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL`／`_OPUS_`／`_HAIKU_` | 它們定義 CLI 的**別名**指向哪個實際模型，會把正規化後的 `sonnet` 又映射回 OpenRouter slug |
+
+第二組特別容易漏，因為它既不認證也不路由。實際踩過的症狀：`.env` 留著 `ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4.6` 時，即使程式已把模型正規化成 `sonnet`，CLI 仍回 404 —— `There's an issue with the selected model (anthropic/claude-sonnet-4.6)`。
 
 `openrouter` 模式下，`OPENROUTER_API_KEY` 會在啟動時被映射為 `ANTHROPIC_AUTH_TOKEN`，且 `ANTHROPIC_API_KEY` 必須留空，否則 SDK 會繞過 OpenRouter 直連 Anthropic。
 
@@ -146,7 +153,7 @@ EOF
 
 > `JWT_SECRET` 未設時會**靜默 fallback 到程式碼內的預設字串**（依賴風險 R2），不會報錯。本機無所謂，但要知道它不會提醒你。
 
-要改用 OpenRouter 的話，把 `LLM_PROVIDER` 改成 `openrouter` 並填入 `OPENROUTER_API_KEY` 即可，其餘不用動——`ANTHROPIC_*` 三個變數由程式依模式自動處理。
+要改用 OpenRouter 的話，把 `LLM_PROVIDER` 改成 `openrouter` 並填入 `OPENROUTER_API_KEY` 即可，其餘不用動——所有 `ANTHROPIC_*` 變數都由程式依模式自動處理（openrouter 模式自動填寫，cli 模式主動刪除，見第 0 節 H1 的表）。
 
 > **本機設定與部署設定是分開的兩套，不要互相抄。** `backend/.env`／`frontend/.env` 只服務本機 bare-metal 執行；部署走 `deploy/.env`（由 `deploy/render-env.sh` 產生，範本 `deploy/.env.example`）。把 `localhost` 來源寫進部署範本、或把 `POSTGRES_*`／`PUBLIC_URL` 寫進本機範本，`scripts/validate_env_contract.py` 都會擋下（CI 紅燈）。
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,7 +17,8 @@
 #
 #   cli   不需要任何金鑰，也不燒 OpenRouter 額度，但需要本機有登入過的
 #         claude CLI（`claude login`）。程式會主動刪除 ANTHROPIC_BASE_URL /
-#         AUTH_TOKEN / API_KEY——它們只要非空就會蓋掉 CLI 自己的登入。
+#         AUTH_TOKEN / API_KEY——它們只要非空就會蓋掉 CLI 自己的登入——
+#         以及 ANTHROPIC_DEFAULT_*_MODEL，它們會把別名映射回 gateway slug。
 #         容器裡沒有互動式登入，所以部署不能用這個模式。
 LLM_PROVIDER=cli
 
@@ -38,6 +39,9 @@ OPENROUTER_API_KEY=
 # 模型名稱。留空時依供應商取預設：cli → sonnet；openrouter →
 # anthropic/claude-sonnet-4.6。cli 模式會忽略含「/」的 gateway 格式名稱。
 LLM_MODEL=
+# 只在 openrouter 模式有意義：它定義 CLI 的 sonnet 別名指向哪個實際模型，
+# 不是「要用哪個模型」。cli 模式會連同 _OPUS_／_HAIKU_ 一起刪除，否則
+# 正規化後的 sonnet 會被映射回 gateway slug，每次請求都 404。
 # ANTHROPIC_DEFAULT_SONNET_MODEL=
 
 # 可選：A3 評核建議改用較快的模型。留空時 cli → haiku；

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,23 +13,36 @@
 # here and nowhere else. Full walkthrough: LOCAL-DEV.md.
 
 # --- LLM (A1 design agent, A3 review suggestions) -----------------------
-# OpenRouter API Key（A1 Design Agent 經 Anthropic Agent SDK 走 OpenRouter）
-OPENROUTER_API_KEY=your_openrouter_api_key_here
+# 供應商：openrouter（預設，部署用）｜cli（本機用，走已登入的 claude CLI）
+#
+#   cli   不需要任何金鑰，也不燒 OpenRouter 額度，但需要本機有登入過的
+#         claude CLI（`claude login`）。程式會主動刪除 ANTHROPIC_BASE_URL /
+#         AUTH_TOKEN / API_KEY——它們只要非空就會蓋掉 CLI 自己的登入。
+#         容器裡沒有互動式登入，所以部署不能用這個模式。
+LLM_PROVIDER=cli
+
+# 以下只有 LLM_PROVIDER=openrouter 時才需要。
+# 留空代表「沒設定」，會得到明確的錯誤訊息；填了佔位字串反而會被當成
+# 真金鑰送出去，換來一個要追三層才看得懂的 401。
+# 例：OPENROUTER_API_KEY=sk-or-v1-xxxxxxxx
+OPENROUTER_API_KEY=
 
 # Anthropic Agent SDK × OpenRouter（官方社群接法）
 # https://openrouter.ai/docs/guides/community/anthropic-agent-sdk
-ANTHROPIC_BASE_URL=https://openrouter.ai/api
-# 啟動時可由 OPENROUTER_API_KEY 自動映射；也可手動填入
-ANTHROPIC_AUTH_TOKEN=
-# 必須顯式為空，避免 SDK 走 Anthropic 直連
-ANTHROPIC_API_KEY=
+# 這三個由程式在 openrouter 模式下自動填寫，通常不需要手動設定；
+# 在 cli 模式下它們會被主動刪除，設了也沒有作用。
+# ANTHROPIC_BASE_URL=https://openrouter.ai/api
+# ANTHROPIC_AUTH_TOKEN=
+# ANTHROPIC_API_KEY=
 
-# Model slug on OpenRouter
-ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4.6
-LLM_MODEL=anthropic/claude-sonnet-4.6
+# 模型名稱。留空時依供應商取預設：cli → sonnet；openrouter →
+# anthropic/claude-sonnet-4.6。cli 模式會忽略含「/」的 gateway 格式名稱。
+LLM_MODEL=
+# ANTHROPIC_DEFAULT_SONNET_MODEL=
 
-# 可選：A3 評核建議改用較快的模型；未設定時沿用 LLM_MODEL
-# REVIEW_LLM_MODEL=anthropic/claude-haiku-4.5
+# 可選：A3 評核建議改用較快的模型。留空時 cli → haiku；
+# openrouter → anthropic/claude-3.5-haiku。
+# REVIEW_LLM_MODEL=
 
 # Agent SDK 輸出 token 上限（OpenRouter 餘額不足時可降低，預設 12000；對應 CLAUDE_CODE_MAX_OUTPUT_TOKENS）
 LLM_MAX_OUTPUT_TOKENS=12000
@@ -39,8 +52,8 @@ LLM_XML_CONTEXT_MAX_CHARS=32000
 # --- n8n（動態架構圖 icons）---------------------------------------------
 # N8N_WEBHOOK URL 空白時走灰底佔位圖；帳密任一為空則不送 Basic Auth header，
 # webhook 會回非 200，同樣落到灰底佔位圖（服務不會壞，但也不會有人通知你）。
-# Example: https://your-n8n-instance.com/webhook/get-icon
-N8N_WEBHOOK_URL=your_n8n_webhook_url_here
+# 例：https://your-n8n-instance.com/webhook/get-icon
+N8N_WEBHOOK_URL=
 N8N_USER=
 N8N_PASSWORD=
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from services.user_router import router as user_router
 from services.collab_router import router as collab_router
 from services.review_router import router as review_router
 from services.lens_router import router as lens_router
-from services.design_agent import configure_openrouter_env
+from services.llm_provider import configure_provider_env
 from database import init_db
 
 # Configure logging
@@ -18,8 +18,8 @@ logger = logging.getLogger("cloud360.main")
 # Load environment variables
 load_dotenv(override=True)
 
-# 將 OPENROUTER_API_KEY 映射為 Agent SDK 所需變數（ANTHROPIC_BASE_URL / AUTH_TOKEN）
-configure_openrouter_env()
+# 依 LLM_PROVIDER 準備 Agent SDK 的環境（OpenRouter 映射，或清掉會蓋掉 CLI 登入的變數）
+configure_provider_env()
 
 app = FastAPI(title="Cloud-360 API")
 
@@ -41,7 +41,7 @@ app.add_middleware(
 @app.on_event("startup")
 def on_startup():
     logger.info("後端服務正在啟動...")
-    configure_openrouter_env()
+    configure_provider_env()
     init_db()
 
 app.include_router(agent_router, prefix="/api/architecture")

--- a/backend/services/agent_router.py
+++ b/backend/services/agent_router.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -31,7 +30,12 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import User
-from services.design_agent import configure_openrouter_env, run_design_agent
+from services.design_agent import run_design_agent
+from services.llm_provider import (
+    auth_error_message,
+    configure_provider_env,
+    llm_auth_ready,
+)
 from services.prompt_guard import (
     REFUSAL_MESSAGE,
     is_platform_self_modification,
@@ -67,14 +71,9 @@ class WaCollabRequest(BaseModel):
 
 
 def _ensure_llm_keys() -> None:
-    configure_openrouter_env()
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
-    auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
-    if not openrouter_key and not auth_token:
-        raise HTTPException(
-            status_code=500,
-            detail="尚未設定 OPENROUTER_API_KEY（Agent SDK 經 OpenRouter 需要此金鑰）",
-        )
+    configure_provider_env()
+    if not llm_auth_ready():
+        raise HTTPException(status_code=500, detail=auth_error_message())
 
 
 def _refusal_sse() -> StreamingResponse:

--- a/backend/services/design_agent.py
+++ b/backend/services/design_agent.py
@@ -9,17 +9,15 @@ design_agent.py — A1 Design Agent（Anthropic Agent SDK + OpenRouter）
   - allowed_tools 僅開放 mcp__cloud360-design__draw_architecture_diagram
   - 明確禁用 Bash / Read / Write / Edit 等檔案與終端工具（Web API 不可開）
 
-環境變數（OpenRouter 官方接法）：
-  ANTHROPIC_BASE_URL=https://openrouter.ai/api
-  ANTHROPIC_AUTH_TOKEN=<OPENROUTER_API_KEY>
-  ANTHROPIC_API_KEY=（必須為空字串）
+供應商與環境變數：
+  由 services.llm_provider 決定（LLM_PROVIDER=openrouter｜cli）。部署走
+  OpenRouter，本機可改用已登入的 claude CLI；細節見該模組。
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -36,8 +34,13 @@ from claude_agent_sdk import (
 from services.diagram_builder import build_mxgraph_xml
 from services.llm_limits import (
     agent_sdk_env,
-    apply_agent_token_limits_to_env,
     truncate_text_for_llm,
+)
+from services.llm_provider import (
+    auth_error_message,
+    configure_provider_env,
+    get_model_name,
+    llm_auth_ready,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,32 +57,6 @@ PROMPT_PATH = (
 # 執行期間由 run_design_agent 注入：進度佇列與最後產出的 XML
 _progress_queue: asyncio.Queue[dict[str, str]] | None = None
 _last_xml: str | None = None
-
-
-def configure_openrouter_env() -> None:
-    """
-    將 OPENROUTER_API_KEY 映射為 Agent SDK 所需的 Anthropic 相容環境變數。
-    必須把 ANTHROPIC_API_KEY 設成空字串，否則 SDK 可能走 Anthropic 直連而非 OpenRouter。
-    """
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-    if not openrouter_key:
-        return
-
-    os.environ["ANTHROPIC_BASE_URL"] = os.environ.get(
-        "ANTHROPIC_BASE_URL", "https://openrouter.ai/api"
-    )
-    # AUTH_TOKEN 優先使用既有值；否則用 OpenRouter key
-    if not os.environ.get("ANTHROPIC_AUTH_TOKEN"):
-        os.environ["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
-    # 強制清空，避免誤走 Anthropic 官方 API
-    os.environ["ANTHROPIC_API_KEY"] = ""
-
-    if not os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL"):
-        os.environ["ANTHROPIC_DEFAULT_SONNET_MODEL"] = os.environ.get(
-            "LLM_MODEL", "anthropic/claude-sonnet-4.6"
-        )
-
-    apply_agent_token_limits_to_env()
 
 
 def load_system_prompt() -> str:
@@ -287,15 +264,10 @@ async def run_design_agent(
     """
     global _progress_queue, _last_xml
 
-    configure_openrouter_env()
+    configure_provider_env()
 
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-    auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN", "").strip()
-    if not openrouter_key and not auth_token:
-        yield {
-            "type": "error",
-            "content": "尚未設定 OPENROUTER_API_KEY（或 ANTHROPIC_AUTH_TOKEN）",
-        }
+    if not llm_auth_ready():
+        yield {"type": "error", "content": auth_error_message()}
         return
 
     _progress_queue = asyncio.Queue()
@@ -304,10 +276,7 @@ async def run_design_agent(
 
     system_prompt = build_system_prompt(current_xml)
     user_prompt = format_user_prompt(messages)
-    model_name = os.environ.get(
-        "LLM_MODEL",
-        os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", "anthropic/claude-sonnet-4.6"),
-    )
+    model_name = get_model_name()
 
     mcp_server = _create_design_mcp_server()
 

--- a/backend/services/diagram_builder.py
+++ b/backend/services/diagram_builder.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -1483,6 +1484,105 @@ def _waypoints_xml(waypoints: list[tuple[float, float]]) -> str:
     )
 
 
+# n8n 的圖示目錄用服務全名（`Simple Notification Service`），架構圖用縮寫
+# （`SNS`）。兩者沒有共同子字串，純比對必然落空——這裡把縮寫展開成目錄裡
+# 實際存在的名稱。每一條都對照 webhook 回傳的目錄驗證過；查無對應的縮寫
+# （如 EFS）不放進來，寧可落到灰底也不要指向錯的圖示。
+_SERVICE_ABBREVIATIONS = {
+    "asg": "auto scaling",
+    "cdn": "cloudfront",
+    "ecr": "elastic container registry",
+    "ecs": "elastic container service",
+    "eks": "elastic kubernetes service",
+    "elb": "elastic load balancing",
+    "iam": "identity and access management",
+    "kms": "key management service",
+    "msk": "managed streaming for apache kafka",
+    "s3": "simple storage service",
+    "ses": "simple email service",
+    "sns": "simple notification service",
+    "sqs": "simple queue service",
+    "vpc": "virtual private cloud",
+}
+
+
+def _normalise_icon_name(text: str) -> str:
+    """比對用的正規化形式。
+
+    目錄裡同一個服務有三種寫法：`AWS Lambda`、`CloudWatch`、
+    `Auto-Scaling-group.svg`。統一成小寫、無副檔名、無 AWS/Amazon 前綴、
+    以單一空白分隔的詞序列，好讓「完全相同」成為可判定的條件。
+    """
+    text = re.sub(r"\.svg$", "", text.strip(), flags=re.IGNORECASE)
+    text = re.sub(r"[^a-zA-Z0-9]+", " ", text).lower().strip()
+    text = re.sub(r"^(aws|amazon)\s+", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _icon_match_score(service_name: str, icon_name: str) -> int:
+    """這個目錄項有多像目標服務。0 代表不算匹配。
+
+    分數的用途是**排序候選**，不是門檻。關鍵在於精確匹配必須贏過子字串
+    包含：`S3` 對 `S3 on Outposts` 是子字串命中，對 `Simple Storage
+    Service` 才是（展開後的）完全相同，而後者才是要的那一個。
+    """
+    service = _normalise_icon_name(service_name)
+    icon = _normalise_icon_name(icon_name)
+    if not service or not icon:
+        return 0
+
+    if service == icon:
+        return 100
+
+    expanded = _SERVICE_ABBREVIATIONS.get(service)
+    if expanded and expanded == icon:
+        return 90
+    if expanded and expanded in icon:
+        return 60
+
+    # 詞邊界包含優於單純的字元包含：`ecs` 不該命中 `secsomething`。
+    if f" {service} " in f" {icon} ":
+        return 50
+    # 只認「服務名是目錄名的一部分」這個方向。反向（目錄名是服務名的一部分）
+    # 實測會讓 `BigQuery` 命中目錄裡叫 `Q` 的圖示、`Cloud Spanner` 命中
+    # `AWS-Cloud`——目錄只收 AWS，非 AWS 服務本來就該落到灰底。長度下限擋掉
+    # 短字串的偶然包含；縮寫由上面的對應表處理，不倚賴這條。
+    if len(service) >= 4 and service in icon:
+        return 10
+    return 0
+
+
+def _select_icon_entry(entries: list[dict[str, Any]], service_name: str) -> dict[str, Any] | None:
+    """挑出最像 `service_name` 的目錄項；沒有像的回 None。
+
+    回 None 而不是退回 `entries[0]`：退回第一項會讓「查無此圖示」看起來
+    像成功，實際交出的是目錄裡碰巧排第一的那個服務（實測是
+    `Auto-Scaling-group`）。錯的圖示比灰底佔位圖更難發現。
+    """
+    best: tuple[int, int, dict[str, Any]] | None = None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("icon_name") or entry.get("service") or ""
+        score = _icon_match_score(service_name, name)
+        if score == 0:
+            continue
+        # 同分時取較短的名稱：`CloudWatch` 勝過 `CloudWatch Logs`。
+        candidate = (score, -len(name), entry)
+        if best is None or candidate[:2] > best[:2]:
+            best = candidate
+    return best[2] if best else None
+
+
+def _svg_from_entry(entry: dict[str, Any]) -> str | None:
+    """目錄項裡的 SVG 內容，欄位名兩種都接受。"""
+    for key in ("svg_content", "svg"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
 async def fetch_icon_from_n8n(service_name: str, provider: str = "AWS") -> str:
     """
     向 n8n webhook 取得服務 SVG。
@@ -1514,6 +1614,14 @@ async def fetch_icon_from_n8n(service_name: str, provider: str = "AWS") -> str:
                 timeout=5.0
             )
             if response.status_code != 200:
+                # 這條路徑原本靜默 return，是最難查的一種降級：服務照常回圖，
+                # 只是每個 icon 都變灰底，沒有任何地方說得出為什麼。
+                logger.warning(
+                    "n8n 取得 %s 圖示（供應商：%s）回應 HTTP %s，改用灰底佔位圖",
+                    service_name,
+                    provider,
+                    response.status_code,
+                )
                 return fallback_svg
 
             content = response.text.strip()
@@ -1523,30 +1631,35 @@ async def fetch_icon_from_n8n(service_name: str, provider: str = "AWS") -> str:
             try:
                 data = response.json()
 
-                if isinstance(data, list) and len(data) > 0:
-                    for item in data:
-                        name = item.get(
-                            "name", item.get("icon_name", item.get("service", ""))
+                if isinstance(data, list):
+                    entry = _select_icon_entry(data, service_name)
+                    if entry is None:
+                        logger.warning(
+                            "n8n 目錄（%d 項）查無 %s（供應商：%s）的圖示，改用灰底佔位圖",
+                            len(data),
+                            service_name,
+                            provider,
                         )
-                        if service_name.lower() in name.lower() or name.lower() in service_name.lower():
-                            if "svg_content" in item:
-                                    return item["svg_content"]
-                            if "svg" in item:
-                                return item["svg"]
-
-                    item = data[0]
-                    if "svg_content" in item:
-                        return item["svg_content"]
-                    if "svg" in item:
-                        return item["svg"]
+                        return fallback_svg
+                    svg = _svg_from_entry(entry)
+                    if svg:
+                        return svg
+                    logger.warning(
+                        "n8n 目錄項 %r 匹配到 %s，但不含 SVG 內容，改用灰底佔位圖",
+                        entry.get("icon_name") or entry.get("name"),
+                        service_name,
+                    )
+                    return fallback_svg
 
                 elif isinstance(data, dict):
-                    if "svg_content" in data:
-                        return data["svg_content"]
-                    if "svg" in data:
-                        return data["svg"]
-                    if "data" in data and "svg" in data["data"]:
-                        return data["data"]["svg"]
+                    svg = _svg_from_entry(data)
+                    if svg:
+                        return svg
+                    nested = data.get("data")
+                    if isinstance(nested, dict):
+                        svg = _svg_from_entry(nested)
+                        if svg:
+                            return svg
 
             except Exception as e:
                 logger.warning("解析 n8n 回應失敗: %s", e)

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -1,0 +1,194 @@
+"""LLM provider selection: the OpenRouter gateway, or the local Claude Code CLI.
+
+Every LLM feature in Cloud-360 runs through claude-agent-sdk, which spawns the
+`claude` CLI as a subprocess. That subprocess can reach a model two ways:
+
+    openrouter   ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN point the CLI at
+    (default)    OpenRouter. This is how the deployed stack runs: a container
+                 has no interactive `claude login` to fall back on.
+
+    cli          The CLI authenticates itself with whatever `claude login`
+                 stored (macOS Keychain, ~/.claude). Local development only --
+                 it needs a logged-in CLI on the same machine, and it spends
+                 the developer's own Claude allowance rather than OpenRouter
+                 credits.
+
+The two are mutually exclusive at the environment level, and the exclusion is
+**not symmetric**. A non-empty ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY takes
+precedence over the CLI's own login and disables it; ANTHROPIC_BASE_URL
+misroutes the CLI outright. Empty values are harmless -- leftover non-empty
+ones are not. So cli mode DELETES those variables instead of blanking them.
+Blanking is what the old code did, and it is not enough: `.env` is loaded with
+override=True, so any value on disk or in the shell reaches the subprocess.
+
+Why an explicit switch rather than "no OpenRouter key means use the CLI": the
+deployed stack must fail loudly when its secret is missing. Auto-detection
+would turn a missing deploy secret into a confusing CLI auth error instead of
+"OPENROUTER_API_KEY is not set".
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from services.llm_limits import apply_agent_token_limits_to_env
+
+logger = logging.getLogger("cloud360.llm_provider")
+
+OPENROUTER = "openrouter"
+CLI = "cli"
+_VALID_PROVIDERS = (OPENROUTER, CLI)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api"
+
+# Anything that routes or authenticates the CLI subprocess. In cli mode each of
+# these must be ABSENT from the environment, not merely empty.
+_CLI_CONFLICTING_VARS = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+)
+
+# OpenRouter addresses models as "<vendor>/<model>"; the CLI uses bare names or
+# aliases. A slug from the wrong provider is rejected at request time, which is
+# far from where the misconfiguration lives.
+_OPENROUTER_DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
+_OPENROUTER_DEFAULT_REVIEW_MODEL = "anthropic/claude-3.5-haiku"
+_CLI_DEFAULT_MODEL = "sonnet"
+_CLI_DEFAULT_REVIEW_MODEL = "haiku"
+
+
+def get_provider() -> str:
+    """Which provider this process uses. Defaults to openrouter.
+
+    An unrecognised value falls back to openrouter with a warning rather than
+    raising: a typo in one optional variable should not stop the whole API from
+    starting, and the fallback still produces the explicit "key not set" error
+    from :func:`auth_error_message` if nothing is configured.
+    """
+    raw = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    if not raw:
+        return OPENROUTER
+    if raw not in _VALID_PROVIDERS:
+        logger.warning(
+            "LLM_PROVIDER=%r 不是有效值（可用：%s），退回 %s",
+            raw,
+            "、".join(_VALID_PROVIDERS),
+            OPENROUTER,
+        )
+        return OPENROUTER
+    return raw
+
+
+def configure_provider_env() -> None:
+    """Prepare the process environment for the selected provider.
+
+    Safe to call repeatedly; both the startup hook and each request call it.
+    """
+    if get_provider() == CLI:
+        _configure_cli_env()
+    else:
+        _configure_openrouter_env()
+
+
+def _configure_cli_env() -> None:
+    removed = [name for name in _CLI_CONFLICTING_VARS if os.environ.pop(name, None) is not None]
+    if removed:
+        # Worth a log line: the developer put these somewhere (.env or shell)
+        # and would otherwise have no idea they are being ignored.
+        logger.info(
+            "LLM_PROVIDER=cli：已移除 %s，改用 claude CLI 自帶的登入認證",
+            "、".join(removed),
+        )
+    apply_agent_token_limits_to_env()
+
+
+def _configure_openrouter_env() -> None:
+    openrouter_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if not openrouter_key:
+        return
+
+    os.environ.setdefault("ANTHROPIC_BASE_URL", OPENROUTER_BASE_URL)
+    if not os.environ.get("ANTHROPIC_AUTH_TOKEN"):
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
+    # Must be empty, or the SDK may reach Anthropic directly instead of OpenRouter.
+    os.environ["ANTHROPIC_API_KEY"] = ""
+
+    if not os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL"):
+        os.environ["ANTHROPIC_DEFAULT_SONNET_MODEL"] = os.environ.get(
+            "LLM_MODEL", _OPENROUTER_DEFAULT_MODEL
+        )
+
+    apply_agent_token_limits_to_env()
+
+
+def llm_auth_ready() -> bool:
+    """Whether an LLM call can be attempted at all.
+
+    In cli mode the CLI owns its own credentials, so the backend cannot inspect
+    them and does not try -- it lets the CLI answer for itself. In openrouter
+    mode a credential must be present in the environment, because without one
+    the request is guaranteed to fail upstream.
+    """
+    if get_provider() == CLI:
+        return True
+    return bool(
+        os.environ.get("OPENROUTER_API_KEY", "").strip()
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN", "").strip()
+    )
+
+
+def auth_error_message() -> str:
+    """The message shown when :func:`llm_auth_ready` is False."""
+    return (
+        "尚未設定 OPENROUTER_API_KEY（Agent SDK 經 OpenRouter 需要此金鑰）。"
+        "本機開發也可改設 LLM_PROVIDER=cli，改用已登入的 claude CLI。"
+    )
+
+
+def _resolve(candidates: tuple[str, ...], default: str, *, provider: str) -> str:
+    for value in candidates:
+        value = (value or "").strip()
+        if not value:
+            continue
+        if provider == CLI and "/" in value:
+            # An OpenRouter slug left over in .env would make every cli-mode
+            # request fail at the CLI with an opaque model error.
+            logger.info(
+                "LLM_PROVIDER=cli：忽略 gateway 格式的模型名稱 %r，改用 %r",
+                value,
+                default,
+            )
+            continue
+        return value
+    return default
+
+
+def get_model_name() -> str:
+    """Model for the design/lens agents."""
+    provider = get_provider()
+    default = _CLI_DEFAULT_MODEL if provider == CLI else _OPENROUTER_DEFAULT_MODEL
+    return _resolve(
+        (
+            os.environ.get("LLM_MODEL", ""),
+            os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", ""),
+        ),
+        default,
+        provider=provider,
+    )
+
+
+def get_review_model_name() -> str:
+    """Model for A3 review suggestions; prefers a faster model."""
+    provider = get_provider()
+    default = _CLI_DEFAULT_REVIEW_MODEL if provider == CLI else _OPENROUTER_DEFAULT_REVIEW_MODEL
+    return _resolve(
+        (
+            os.environ.get("REVIEW_LLM_MODEL", ""),
+            os.environ.get("LLM_MODEL", ""),
+            os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", ""),
+        ),
+        default,
+        provider=provider,
+    )

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -21,6 +21,15 @@ ones are not. So cli mode DELETES those variables instead of blanking them.
 Blanking is what the old code did, and it is not enough: `.env` is loaded with
 override=True, so any value on disk or in the shell reaches the subprocess.
 
+The ANTHROPIC_DEFAULT_*_MODEL family has to be deleted for the same reason,
+and it is easy to miss because it neither authenticates nor routes. Those
+variables define what the CLI's *aliases* resolve to: with
+ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4.6 in the environment,
+asking the CLI for `sonnet` gets you that OpenRouter slug sent to Anthropic,
+which answers 404. That silently cancels the model normalisation below --
+:func:`get_model_name` maps the leftover slug to a bare `sonnet`, and the alias
+mapping maps it straight back.
+
 Why an explicit switch rather than "no OpenRouter key means use the CLI": the
 deployed stack must fail loudly when its secret is missing. Auto-detection
 would turn a missing deploy secret into a confusing CLI auth error instead of
@@ -44,11 +53,21 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 
 # Anything that routes or authenticates the CLI subprocess. In cli mode each of
 # these must be ABSENT from the environment, not merely empty.
-_CLI_CONFLICTING_VARS = (
+_CLI_AUTH_VARS = (
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_API_KEY",
 )
+
+# What the CLI's model aliases (sonnet/opus/haiku) resolve to. A gateway slug
+# left here re-applies itself after normalisation and every request 404s.
+_CLI_ALIAS_MODEL_VARS = (
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+_CLI_CONFLICTING_VARS = _CLI_AUTH_VARS + _CLI_ALIAS_MODEL_VARS
 
 # OpenRouter addresses models as "<vendor>/<model>"; the CLI uses bare names or
 # aliases. A slug from the wrong provider is rejected at request time, which is
@@ -165,15 +184,25 @@ def _resolve(candidates: tuple[str, ...], default: str, *, provider: str) -> str
     return default
 
 
+def _sonnet_alias_candidate(provider: str) -> tuple[str, ...]:
+    """ANTHROPIC_DEFAULT_SONNET_MODEL as a model source, where that is meaningful.
+
+    Only under openrouter. Under cli the variable does not name the model to
+    use -- it redefines what the `sonnet` alias points at -- so reading it as a
+    model name would reintroduce the very slug :func:`_configure_cli_env`
+    deletes, and would do so even before that function has run.
+    """
+    if provider == CLI:
+        return ()
+    return (os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", ""),)
+
+
 def get_model_name() -> str:
     """Model for the design/lens agents."""
     provider = get_provider()
     default = _CLI_DEFAULT_MODEL if provider == CLI else _OPENROUTER_DEFAULT_MODEL
     return _resolve(
-        (
-            os.environ.get("LLM_MODEL", ""),
-            os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", ""),
-        ),
+        (os.environ.get("LLM_MODEL", ""),) + _sonnet_alias_candidate(provider),
         default,
         provider=provider,
     )
@@ -187,8 +216,8 @@ def get_review_model_name() -> str:
         (
             os.environ.get("REVIEW_LLM_MODEL", ""),
             os.environ.get("LLM_MODEL", ""),
-            os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", ""),
-        ),
+        )
+        + _sonnet_alias_candidate(provider),
         default,
         provider=provider,
     )

--- a/backend/services/review_agent.py
+++ b/backend/services/review_agent.py
@@ -9,12 +9,16 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from services.design_agent import configure_openrouter_env
+from services.llm_provider import (
+    auth_error_message,
+    configure_provider_env,
+    get_review_model_name,
+    llm_auth_ready,
+)
 from services.llm_limits import agent_sdk_env
 
 logger = logging.getLogger("cloud360.review_agent")
@@ -115,11 +119,9 @@ async def run_review_agent(
         TextBlock,
     )
 
-    configure_openrouter_env()
-    openrouter_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-    auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN", "").strip()
-    if not openrouter_key and not auth_token:
-        raise RuntimeError("尚未設定 OPENROUTER_API_KEY（或 ANTHROPIC_AUTH_TOKEN）")
+    configure_provider_env()
+    if not llm_auth_ready():
+        raise RuntimeError(auth_error_message())
 
     payload = _compact_payload(diagram_summary, rule_result)
     user_prompt = (
@@ -130,13 +132,8 @@ async def run_review_agent(
         "勿呼叫任何工具：\n"
         f"```json\n{json.dumps(payload, ensure_ascii=False)}\n```"
     )
-    # Prefer faster model for review suggestions; override with REVIEW_LLM_MODEL
-    model_name = (
-        os.environ.get("REVIEW_LLM_MODEL", "").strip()
-        or os.environ.get("LLM_MODEL", "").strip()
-        or os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", "").strip()
-        or "anthropic/claude-3.5-haiku"
-    )
+    # Prefers a faster model; override with REVIEW_LLM_MODEL.
+    model_name = get_review_model_name()
     options = ClaudeAgentOptions(
         system_prompt=load_review_system_prompt(),
         model=model_name,

--- a/backend/services/wa_lens_engine.py
+++ b/backend/services/wa_lens_engine.py
@@ -447,15 +447,18 @@ async def answer_lens_with_agent(
     Ask ReviewAgent-style LLM to pick choices. Falls back to heuristic on failure.
     POC: prefer heuristic first if no API key (fast + testable); try agent when key present.
     """
-    import os
-
-    from services.design_agent import configure_openrouter_env
+    from services.llm_provider import (
+        auth_error_message,
+        configure_provider_env,
+        get_model_name,
+        llm_auth_ready,
+    )
     from services.llm_limits import agent_sdk_env, get_xml_context_max_chars
 
-    configure_openrouter_env()
-    key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-    token = os.environ.get("ANTHROPIC_AUTH_TOKEN", "").strip()
-    if not key and not token:
+    configure_provider_env()
+    if not llm_auth_ready():
+        # Falling back silently would look identical to a real LLM answer; say so.
+        logger.warning("A3 lens 改用規則啟發式（未呼叫 LLM）：%s", auth_error_message())
         # Caller should pass xml for heuristic; here we only have summary → empty-ish
         blob = json.dumps(diagram_summary, ensure_ascii=False).lower()
         # Minimal map from summary text
@@ -518,10 +521,7 @@ async def answer_lens_with_agent(
     mcp = create_sdk_mcp_server(
         name="cloud360-lens", version="1.0.0", tools=[emit_lens_answers]
     )
-    model_name = os.environ.get(
-        "LLM_MODEL",
-        os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", "anthropic/claude-sonnet-4.6"),
-    )
+    model_name = get_model_name()
     diagram_cap = get_xml_context_max_chars()
     prompt = (
         "你是離線 Well-Architected 評核助理。根據架構圖摘要，為每題勾選適用的 best practice "

--- a/backend/tests/test_diagram_icons.py
+++ b/backend/tests/test_diagram_icons.py
@@ -1,0 +1,196 @@
+"""Tests for n8n icon lookup (services.diagram_builder).
+
+`fetch_icon_from_n8n` is mocked out in every other diagram test, so nothing
+covered how a catalogue entry is chosen. Two defects lived there:
+
+  * a miss fell back to `data[0]` -- the catalogue's first entry, observed to
+    be `Auto-Scaling-group`. SNS and KMS both rendered as an Auto Scaling icon
+    with no log line. A wrong icon is harder to notice than a grey box.
+  * the first substring hit won, so `S3` matched `S3 on Outposts` instead of
+    `Simple Storage Service`.
+
+The fixtures below use the real catalogue's shape and names (315 AWS entries,
+`icon_name` + `svg_content`).
+"""
+
+import logging
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import tests.helpers  # noqa: F401  -- installs the psycopg2 stub before services import
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from services.diagram_builder import (
+    _icon_match_score,
+    _normalise_icon_name,
+    _select_icon_entry,
+    fetch_icon_from_n8n,
+)
+
+# Names taken verbatim from the live catalogue.
+CATALOGUE = [
+    {"icon_name": "Auto-Scaling-group.svg", "svg_content": "<svg>asg</svg>"},
+    {"icon_name": "AWS Lambda", "svg_content": "<svg>lambda</svg>"},
+    {"icon_name": "S3 on Outposts", "svg_content": "<svg>outposts</svg>"},
+    {"icon_name": "Simple Storage Service", "svg_content": "<svg>s3</svg>"},
+    {"icon_name": "Simple Storage Service Glacier", "svg_content": "<svg>glacier</svg>"},
+    {"icon_name": "Simple Notification Service", "svg_content": "<svg>sns</svg>"},
+    {"icon_name": "AWS Key Management Service", "svg_content": "<svg>kms</svg>"},
+    {"icon_name": "CloudWatch", "svg_content": "<svg>cw</svg>"},
+    {"icon_name": "CloudWatch Logs", "svg_content": "<svg>cwlogs</svg>"},
+    {"icon_name": "AWS WAF", "svg_content": "<svg>waf</svg>"},
+]
+
+
+def _name_of(entry):
+    return entry["icon_name"] if entry else None
+
+
+class Normalisation(unittest.TestCase):
+    def test_strips_svg_suffix_and_vendor_prefix(self):
+        self.assertEqual(_normalise_icon_name("Auto-Scaling-group.svg"), "auto scaling group")
+        self.assertEqual(_normalise_icon_name("AWS Lambda"), "lambda")
+        self.assertEqual(_normalise_icon_name("Amazon CloudWatch"), "cloudwatch")
+
+    def test_is_punctuation_and_case_insensitive(self):
+        self.assertEqual(_normalise_icon_name("API-Gateway"), _normalise_icon_name("api gateway"))
+
+
+class Selection(unittest.TestCase):
+    def test_expands_abbreviations_the_catalogue_does_not_use(self):
+        """The catalogue has no entry containing "SNS" or "KMS" at all."""
+        self.assertEqual(
+            _name_of(_select_icon_entry(CATALOGUE, "SNS")), "Simple Notification Service"
+        )
+        self.assertEqual(
+            _name_of(_select_icon_entry(CATALOGUE, "KMS")), "AWS Key Management Service"
+        )
+
+    def test_exact_match_beats_substring_hit(self):
+        """`S3` is a substring of `S3 on Outposts`; the wanted entry is not."""
+        self.assertEqual(
+            _name_of(_select_icon_entry(CATALOGUE, "S3")), "Simple Storage Service"
+        )
+
+    def test_prefers_the_shorter_name_on_a_tie(self):
+        self.assertEqual(_name_of(_select_icon_entry(CATALOGUE, "CloudWatch")), "CloudWatch")
+
+    def test_vendor_prefix_does_not_prevent_an_exact_match(self):
+        self.assertEqual(_name_of(_select_icon_entry(CATALOGUE, "Lambda")), "AWS Lambda")
+        self.assertEqual(_name_of(_select_icon_entry(CATALOGUE, "WAF")), "AWS WAF")
+
+    def test_a_miss_returns_none_rather_than_the_first_entry(self):
+        """The regression: this used to hand back `Auto-Scaling-group`."""
+        self.assertIsNone(_select_icon_entry(CATALOGUE, "Cloud Spanner"))
+        self.assertIsNone(_select_icon_entry(CATALOGUE, "BigQuery"))
+
+    def test_a_catalogue_name_buried_in_the_service_name_is_not_a_match(self):
+        """Observed against the live catalogue, which holds only AWS icons.
+
+        `Q` is a real entry there, and `"q"` is a substring of `"bigquery"`.
+        `AWS-Cloud` normalises to `cloud`, a substring of `cloud spanner`.
+        Both produced a confident, wrong icon for a non-AWS service.
+        """
+        catalogue = CATALOGUE + [
+            {"icon_name": "Q", "svg_content": "<svg>q</svg>"},
+            {"icon_name": "AWS-Cloud.svg", "svg_content": "<svg>cloud</svg>"},
+        ]
+        self.assertIsNone(_select_icon_entry(catalogue, "BigQuery"))
+        self.assertIsNone(_select_icon_entry(catalogue, "Cloud Spanner"))
+        # The same entries must still be reachable when actually asked for.
+        self.assertEqual(_name_of(_select_icon_entry(catalogue, "Q")), "Q")
+
+    def test_ignores_non_dict_entries(self):
+        self.assertIsNone(_select_icon_entry(["nonsense", 42], "Lambda"))
+
+    @given(st.text(min_size=1, max_size=30))
+    def test_never_returns_an_unmatched_entry(self, service_name):
+        """Whatever is asked for, the answer is either a real match or None."""
+        entry = _select_icon_entry(CATALOGUE, service_name)
+        if entry is not None:
+            self.assertGreater(_icon_match_score(service_name, entry["icon_name"]), 0)
+
+
+class WordBoundary(unittest.TestCase):
+    def test_word_boundary_scores_above_bare_substring(self):
+        boundary = _icon_match_score("gateway", "API Gateway")
+        buried = _icon_match_score("ecs", "Secsomething")
+        self.assertGreater(boundary, buried)
+
+
+def _response(status_code=200, payload=None, text=""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+def _client_returning(response):
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class FetchFallsBackLoudly(unittest.IsolatedAsyncioTestCase):
+    """Every degraded path must say so; a grey icon must never be silent."""
+
+    async def _fetch(self, response, service="Lambda"):
+        with patch.dict("os.environ", {"N8N_WEBHOOK_URL": "https://n8n.example/webhook"}):
+            with patch("httpx.AsyncClient", return_value=_client_returning(response)):
+                with self.assertLogs("services.diagram_builder", level="WARNING") as logs:
+                    svg = await fetch_icon_from_n8n(service)
+        return svg, "\n".join(logs.output)
+
+    async def test_non_200_is_logged(self):
+        svg, logged = await self._fetch(_response(status_code=503))
+        self.assertIn("#cccccc", svg)
+        self.assertIn("503", logged)
+
+    async def test_catalogue_miss_is_logged(self):
+        svg, logged = await self._fetch(_response(payload=CATALOGUE), service="Cloud Spanner")
+        self.assertIn("#cccccc", svg)
+        self.assertIn("Cloud Spanner", logged)
+
+    async def test_matched_entry_without_svg_is_logged(self):
+        payload = [{"icon_name": "AWS Lambda"}]
+        svg, logged = await self._fetch(_response(payload=payload))
+        self.assertIn("#cccccc", svg)
+        self.assertIn("SVG", logged)
+
+
+class FetchSucceeds(unittest.IsolatedAsyncioTestCase):
+    async def _fetch(self, response, service):
+        with patch.dict("os.environ", {"N8N_WEBHOOK_URL": "https://n8n.example/webhook"}):
+            with patch("httpx.AsyncClient", return_value=_client_returning(response)):
+                return await fetch_icon_from_n8n(service)
+
+    async def test_returns_the_matched_svg(self):
+        svg = await self._fetch(_response(payload=CATALOGUE), "SNS")
+        self.assertEqual(svg, "<svg>sns</svg>")
+
+    async def test_accepts_a_raw_svg_body(self):
+        svg = await self._fetch(_response(text="<svg>direct</svg>"), "Lambda")
+        self.assertEqual(svg, "<svg>direct</svg>")
+
+    async def test_accepts_a_dict_payload(self):
+        svg = await self._fetch(_response(payload={"svg_content": "<svg>d</svg>"}), "Lambda")
+        self.assertEqual(svg, "<svg>d</svg>")
+
+    async def test_accepts_a_nested_dict_payload(self):
+        svg = await self._fetch(_response(payload={"data": {"svg": "<svg>n</svg>"}}), "Lambda")
+        self.assertEqual(svg, "<svg>n</svg>")
+
+    async def test_unset_webhook_url_returns_the_placeholder(self):
+        with patch.dict("os.environ", {"N8N_WEBHOOK_URL": ""}):
+            svg = await fetch_icon_from_n8n("Lambda")
+        self.assertIn("#cccccc", svg)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARNING)
+    unittest.main()

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,0 +1,184 @@
+"""Tests for LLM provider selection (services.llm_provider).
+
+The behaviour under test is what made the cli path unreachable before: the
+guards demanded a non-empty credential, while a non-empty credential is exactly
+what disables the CLI's own login. Each case below pins one half of that.
+"""
+
+import os
+import unittest
+from contextlib import contextmanager
+
+import tests.helpers  # noqa: F401  -- installs the psycopg2 stub before services import
+
+from services.llm_provider import (
+    CLI,
+    OPENROUTER,
+    auth_error_message,
+    configure_provider_env,
+    get_model_name,
+    get_provider,
+    get_review_model_name,
+    llm_auth_ready,
+)
+
+MANAGED = (
+    "LLM_PROVIDER",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "LLM_MODEL",
+    "REVIEW_LLM_MODEL",
+)
+
+
+@contextmanager
+def env(**values):
+    """Run with exactly `values` set among MANAGED; everything else removed."""
+    saved = {k: os.environ.get(k) for k in MANAGED}
+    try:
+        for k in MANAGED:
+            os.environ.pop(k, None)
+        for k, v in values.items():
+            os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class ProviderSelection(unittest.TestCase):
+    def test_defaults_to_openrouter_when_unset(self):
+        with env():
+            self.assertEqual(get_provider(), OPENROUTER)
+
+    def test_reads_cli(self):
+        with env(LLM_PROVIDER="cli"):
+            self.assertEqual(get_provider(), CLI)
+
+    def test_is_case_and_whitespace_insensitive(self):
+        with env(LLM_PROVIDER="  CLI  "):
+            self.assertEqual(get_provider(), CLI)
+
+    def test_unknown_value_falls_back_to_openrouter(self):
+        with env(LLM_PROVIDER="anthropic-direct"):
+            with self.assertLogs("cloud360.llm_provider", level="WARNING"):
+                self.assertEqual(get_provider(), OPENROUTER)
+
+
+class CliModeClearsConflictingVars(unittest.TestCase):
+    """A non-empty value in any of these disables the CLI's own login."""
+
+    def test_deletes_rather_than_blanks(self):
+        with env(
+            LLM_PROVIDER="cli",
+            ANTHROPIC_BASE_URL="https://openrouter.ai/api",
+            ANTHROPIC_AUTH_TOKEN="sk-or-leftover",
+            ANTHROPIC_API_KEY="sk-ant-leftover",
+        ):
+            configure_provider_env()
+            # Absent, not empty: an empty string would still be inherited by the
+            # subprocess, and an empty ANTHROPIC_BASE_URL is worse than none.
+            for name in ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"):
+                self.assertNotIn(name, os.environ, f"{name} should be removed entirely")
+
+    def test_clears_even_when_openrouter_key_is_present(self):
+        with env(LLM_PROVIDER="cli", OPENROUTER_API_KEY="sk-or-real"):
+            configure_provider_env()
+            self.assertNotIn("ANTHROPIC_AUTH_TOKEN", os.environ)
+
+    def test_is_idempotent(self):
+        with env(LLM_PROVIDER="cli", ANTHROPIC_API_KEY="x"):
+            configure_provider_env()
+            configure_provider_env()
+            self.assertNotIn("ANTHROPIC_API_KEY", os.environ)
+
+
+class OpenRouterModeMapsTheKey(unittest.TestCase):
+    def test_maps_key_to_auth_token(self):
+        with env(LLM_PROVIDER="openrouter", OPENROUTER_API_KEY="sk-or-real"):
+            configure_provider_env()
+            self.assertEqual(os.environ["ANTHROPIC_AUTH_TOKEN"], "sk-or-real")
+            self.assertEqual(os.environ["ANTHROPIC_BASE_URL"], "https://openrouter.ai/api")
+            self.assertEqual(os.environ["ANTHROPIC_API_KEY"], "")
+
+    def test_touches_nothing_without_a_key(self):
+        with env(LLM_PROVIDER="openrouter"):
+            configure_provider_env()
+            self.assertNotIn("ANTHROPIC_AUTH_TOKEN", os.environ)
+
+    def test_does_not_overwrite_an_explicit_auth_token(self):
+        with env(
+            LLM_PROVIDER="openrouter",
+            OPENROUTER_API_KEY="sk-or-real",
+            ANTHROPIC_AUTH_TOKEN="explicit",
+        ):
+            configure_provider_env()
+            self.assertEqual(os.environ["ANTHROPIC_AUTH_TOKEN"], "explicit")
+
+
+class AuthReadiness(unittest.TestCase):
+    def test_cli_is_always_ready(self):
+        """The CLI owns its credentials; the backend cannot and must not judge."""
+        with env(LLM_PROVIDER="cli"):
+            self.assertTrue(llm_auth_ready())
+
+    def test_openrouter_needs_a_credential(self):
+        with env(LLM_PROVIDER="openrouter"):
+            self.assertFalse(llm_auth_ready())
+
+    def test_openrouter_accepts_either_variable(self):
+        with env(LLM_PROVIDER="openrouter", OPENROUTER_API_KEY="k"):
+            self.assertTrue(llm_auth_ready())
+        with env(LLM_PROVIDER="openrouter", ANTHROPIC_AUTH_TOKEN="t"):
+            self.assertTrue(llm_auth_ready())
+
+    def test_whitespace_only_is_not_a_credential(self):
+        with env(LLM_PROVIDER="openrouter", OPENROUTER_API_KEY="   "):
+            self.assertFalse(llm_auth_ready())
+
+    def test_error_message_names_both_ways_out(self):
+        message = auth_error_message()
+        self.assertIn("OPENROUTER_API_KEY", message)
+        self.assertIn("LLM_PROVIDER=cli", message)
+
+
+class ModelSelection(unittest.TestCase):
+    def test_provider_specific_defaults(self):
+        with env(LLM_PROVIDER="openrouter"):
+            self.assertEqual(get_model_name(), "anthropic/claude-sonnet-4.6")
+        with env(LLM_PROVIDER="cli"):
+            self.assertEqual(get_model_name(), "sonnet")
+
+    def test_explicit_model_wins(self):
+        with env(LLM_PROVIDER="cli", LLM_MODEL="opus"):
+            self.assertEqual(get_model_name(), "opus")
+
+    def test_cli_ignores_a_gateway_slug(self):
+        """A slug left over from openrouter mode would fail at the CLI."""
+        with env(LLM_PROVIDER="cli", LLM_MODEL="anthropic/claude-sonnet-4.6"):
+            with self.assertLogs("cloud360.llm_provider", level="INFO"):
+                self.assertEqual(get_model_name(), "sonnet")
+
+    def test_openrouter_keeps_the_gateway_slug(self):
+        with env(LLM_PROVIDER="openrouter", LLM_MODEL="anthropic/claude-opus-4.1"):
+            self.assertEqual(get_model_name(), "anthropic/claude-opus-4.1")
+
+    def test_review_model_prefers_its_own_override(self):
+        with env(LLM_PROVIDER="cli", LLM_MODEL="opus", REVIEW_LLM_MODEL="haiku"):
+            self.assertEqual(get_review_model_name(), "haiku")
+
+    def test_review_model_defaults_per_provider(self):
+        with env(LLM_PROVIDER="cli"):
+            self.assertEqual(get_review_model_name(), "haiku")
+        with env(LLM_PROVIDER="openrouter"):
+            self.assertEqual(get_review_model_name(), "anthropic/claude-3.5-haiku")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -29,6 +29,8 @@ MANAGED = (
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     "LLM_MODEL",
     "REVIEW_LLM_MODEL",
 )
@@ -97,6 +99,45 @@ class CliModeClearsConflictingVars(unittest.TestCase):
             configure_provider_env()
             configure_provider_env()
             self.assertNotIn("ANTHROPIC_API_KEY", os.environ)
+
+    def test_deletes_the_alias_model_family(self):
+        """These name what `sonnet`/`opus`/`haiku` resolve to, not the model.
+
+        Observed 404: with ANTHROPIC_DEFAULT_SONNET_MODEL left at an OpenRouter
+        slug, `claude -p ... --model sonnet` reported "There's an issue with the
+        selected model (anthropic/claude-sonnet-4.6)". Normalising the model
+        name is not enough while the alias maps it back.
+        """
+        with env(
+            LLM_PROVIDER="cli",
+            ANTHROPIC_DEFAULT_SONNET_MODEL="anthropic/claude-sonnet-4.6",
+            ANTHROPIC_DEFAULT_OPUS_MODEL="anthropic/claude-opus-4.1",
+            ANTHROPIC_DEFAULT_HAIKU_MODEL="anthropic/claude-3.5-haiku",
+        ):
+            configure_provider_env()
+            for name in (
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            ):
+                self.assertNotIn(name, os.environ, f"{name} should be removed entirely")
+
+    def test_no_gateway_slug_survives_anywhere(self):
+        """The real `backend/.env` shape that produced the 404, end to end."""
+        with env(
+            LLM_PROVIDER="cli",
+            ANTHROPIC_BASE_URL="https://openrouter.ai/api",
+            ANTHROPIC_DEFAULT_SONNET_MODEL="anthropic/claude-sonnet-4.6",
+            LLM_MODEL="anthropic/claude-sonnet-4.6",
+        ):
+            configure_provider_env()
+            leftovers = {
+                name: value
+                for name, value in os.environ.items()
+                if name.startswith("ANTHROPIC_") and "/" in value
+            }
+            self.assertEqual(leftovers, {}, "a gateway slug reached the CLI subprocess")
+            self.assertEqual(get_model_name(), "sonnet")
 
 
 class OpenRouterModeMapsTheKey(unittest.TestCase):
@@ -168,6 +209,24 @@ class ModelSelection(unittest.TestCase):
     def test_openrouter_keeps_the_gateway_slug(self):
         with env(LLM_PROVIDER="openrouter", LLM_MODEL="anthropic/claude-opus-4.1"):
             self.assertEqual(get_model_name(), "anthropic/claude-opus-4.1")
+
+    def test_openrouter_falls_back_to_the_sonnet_alias_variable(self):
+        with env(
+            LLM_PROVIDER="openrouter",
+            ANTHROPIC_DEFAULT_SONNET_MODEL="anthropic/claude-opus-4.1",
+        ):
+            self.assertEqual(get_model_name(), "anthropic/claude-opus-4.1")
+
+    def test_cli_never_reads_the_sonnet_alias_variable(self):
+        """Even a bare name there means "what `sonnet` resolves to", not "use this".
+
+        Asserted without calling configure_provider_env() on purpose: the model
+        choice must not depend on whether the environment has been cleaned yet.
+        """
+        with env(LLM_PROVIDER="cli", ANTHROPIC_DEFAULT_SONNET_MODEL="opus"):
+            self.assertEqual(get_model_name(), "sonnet")
+        with env(LLM_PROVIDER="cli", ANTHROPIC_DEFAULT_SONNET_MODEL="opus"):
+            self.assertEqual(get_review_model_name(), "haiku")
 
     def test_review_model_prefers_its_own_override(self):
         with env(LLM_PROVIDER="cli", LLM_MODEL="opus", REVIEW_LLM_MODEL="haiku"):

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -19,18 +19,29 @@
 #   VITE_API_BASE_URL   the frontend build arg, taken from PUBLIC_URL
 
 # --- Database -----------------------------------------------------------
+# Left empty deliberately: a filled-in-looking placeholder (change_me) passes a
+# casual review and ends up as the real database password. Generate one with
+# `openssl rand -hex 32` -- and no `$`, which compose would truncate.
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change_me
+POSTGRES_PASSWORD=
 POSTGRES_DB=cloud360
 
 # --- Backend ------------------------------------------------------------
 # JWT signing key. Generate with: openssl rand -hex 32
-# Leaving this unset makes auth.py fall back to a key published in this repo,
-# so anyone could forge an admin session.
-JWT_SECRET=change_me
+# Left empty deliberately, for the same reason as POSTGRES_PASSWORD above. It
+# MUST be filled in: auth.py falls back to a key published in this repo when
+# this is unset, and anyone could then forge an admin session. The GitHub
+# Actions path cannot regress here -- deploy/render-env.sh refuses to render
+# without it -- but a hand-copied file on the host has no such guard.
+JWT_SECRET=
 
 # A1 design agent — Anthropic Agent SDK routed through OpenRouter.
 # Runtime still needs Claude Code CLI inside the backend image (see Dockerfile / DEPLOY.md §0).
+#
+# Always openrouter for a deployed stack. The alternative (cli) authenticates
+# with an interactive `claude login`, which a container cannot do -- it is a
+# local-development mode only, set in backend/.env.
+LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=
 ANTHROPIC_BASE_URL=https://openrouter.ai/api
 ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4.6

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -35,6 +35,9 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
+      # No fallback on purpose: this makes scripts/validate_env_contract.py
+      # require render-env.sh and deploy/.env.example to keep writing it.
+      LLM_PROVIDER: ${LLM_PROVIDER}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL}
       ANTHROPIC_DEFAULT_SONNET_MODEL: ${ANTHROPIC_DEFAULT_SONNET_MODEL}

--- a/deploy/render-env.sh
+++ b/deploy/render-env.sh
@@ -22,6 +22,10 @@
 #   N8N_PASSWORD       optional   basic auth for the n8n webhook
 #   APP_ENV            optional   defaults to staging
 #
+# LLM_PROVIDER is pinned to openrouter here and is not overridable: the other
+# mode (cli) needs an interactively logged-in claude CLI, which a container
+# does not have.
+#
 # Usage: deploy/render-env.sh [output-path]   (default: deploy/.env)
 
 set -euo pipefail
@@ -60,6 +64,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 POSTGRES_DB=cloud360
 JWT_SECRET=${JWT_SECRET}
+LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
 ANTHROPIC_BASE_URL=https://openrouter.ai/api
 ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4.6

--- a/scripts/validate_env_contract.py
+++ b/scripts/validate_env_contract.py
@@ -79,6 +79,11 @@ DEV_ONLY_MARKERS = ("localhost", "127.0.0.1")
 COMPOSE_VAR = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:?[-?+])?")
 ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=", re.MULTILINE)
 COMMENTED_ASSIGNMENT = re.compile(r"^\s*#\s*([A-Za-z_][A-Za-z0-9_]*)=", re.MULTILINE)
+# "your_openrouter_api_key_here", "changeme", "<your-token>", "TODO" ...
+PLACEHOLDER_VALUE = re.compile(
+    r"^(your[_-].*|.*[_-]here|<.*>|changeme|change[_-]me|xxx+|todo|placeholder)$",
+    re.IGNORECASE,
+)
 PY_ENV_READ = re.compile(
     r"""os\.(?:environ\.get|getenv)\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""
 )
@@ -255,6 +260,38 @@ def validate_local_dev_template_is_complete() -> int:
     return 0
 
 
+def validate_templates_ship_no_placeholder_values() -> int:
+    """A template must express "not configured" as an empty value.
+
+    Code decides a feature is configured by testing the variable for a non-empty
+    value. A placeholder like ``your_openrouter_api_key_here`` is non-empty, so
+    copying the template and not filling it in does not read as "unset" -- it
+    reads as a credential, and gets sent upstream. The resulting failure is an
+    authentication error three layers away from the file that caused it, rather
+    than the clear "not set" message the code already knows how to produce.
+    """
+    violations: list[str] = []
+    for template in (BACKEND_TEMPLATE, FRONTEND_TEMPLATE, DEPLOY_TEMPLATE):
+        for lineno, line in enumerate(read(template).splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            match = re.match(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line)
+            if match is None:
+                continue
+            value = match.group(2).strip().strip("\"'")
+            if PLACEHOLDER_VALUE.match(value):
+                violations.append(f"{template}:{lineno} {match.group(1)}={value}")
+
+    if violations:
+        return fail(
+            "Template(s) ship a non-empty placeholder value:\n  - "
+            + "\n  - ".join(violations)
+            + "\nLeave the value empty and put the example in a comment above it, "
+            "so an unfilled template reads as unset rather than as a credential."
+        )
+    return 0
+
+
 def main() -> int:
     checks = (
         validate_workflow_uses_the_renderer,
@@ -263,6 +300,7 @@ def main() -> int:
         validate_deploy_template_sets_nothing_derived,
         validate_scopes_are_separated,
         validate_local_dev_template_is_complete,
+        validate_templates_ship_no_placeholder_values,
     )
     for check in checks:
         result = check()


### PR DESCRIPTION
## 問題

本機開發一定要一把 OpenRouter 金鑰，而且**用訂閱制認證的人在改程式碼之前根本走不通**。這不是設定沒設對，是一個死結：

- 四道 guard 要求 `OPENROUTER_API_KEY` 或 `ANTHROPIC_AUTH_TOKEN` **非空**，否則拒絕
- 但 `ANTHROPIC_AUTH_TOKEN` 一旦非空，就會**蓋掉 claude.ai 的登入**

要通過 guard 就必須放非空值；放了非空值就用不到自己的登入。CLI 根本沒被 spawn 就被擋下了。

實測釘死的觸發條件：

| 環境（非空時） | 症狀 |
|---|---|
| `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` | `⚠ connectors are disabled ... takes precedence over your claude.ai login` |
| `ANTHROPIC_BASE_URL` | 請求被導去別的端點 → Execution error |
| 以上皆為**空字串** | 無害，Keychain 登入正常運作 |

## 作法：顯式開關 `LLM_PROVIDER`

| 值 | 認證 | 用途 |
|---|---|---|
| `openrouter`（程式預設） | `OPENROUTER_API_KEY` | 部署。**行為完全不變**，deploy 端另外寫死不靠預設值 |
| `cli` | `claude login` 的登入（Keychain） | 本機。不需金鑰、不燒 OpenRouter 額度 |

選顯式開關而非自動偵測（「沒金鑰就用 CLI」）的理由：部署端的 secret 漏設必須**大聲失敗**。自動偵測會把「忘了設 secret」變成一個 CLI 認證錯誤，而不是「OPENROUTER_API_KEY 沒設」。

`cli` 模式**刪除**而非設空那三個變數。設空不夠——`.env` 是以 `override=True` 載入的，磁碟或 shell 上的殘值都會被子行程繼承。

模型名稱隨供應商取預設，且 cli 模式會忽略含 `/` 的 gateway 格式名稱；否則 `.env` 裡殘留的 OpenRouter slug 會讓每次請求都在 CLI 端失敗。

## 順帶修掉的兩件事

**四道逐字重複的 guard** 收斂成 `services/llm_provider` 的單一判斷。其中 `wa_lens_engine` 原本是**靜默**退回規則啟發式——使用者看不出 A3 的答案不是 LLM 產生的；現在會寫 WARNING。

**範本的佔位字串**。`.env.example` 出貨的 `OPENROUTER_API_KEY=your_openrouter_api_key_here` 是**非空**的，而程式判斷「有沒有設定」看的是非空。所以照著範本複製、還沒填金鑰的人，拿到的不是「你還沒設定」，而是離肇因三層遠的 401：

```
佔位字串當 token → {"message":"Missing Authentication header"}     ← 使用者實際遇到的
完全不帶 header  → {"message":"No cookie auth credentials found"}
```

範本改為一律出空值、範例寫在註解裡，並在 `validate_env_contract.py` 加**第七道檢查**擋下整類佔位值。它同時抓出 `deploy/.env.example` 的 `POSTGRES_PASSWORD=change_me` 與 `JWT_SECRET=change_me`——那兩個看起來像填好了，真的複製去用就是拿已知弱密碼在跑。

## 驗證

- **189 個測試通過**（新增 21 個，涵蓋 provider × 憑證 × 模型的組合，不只 happy path）
- **突變測試**：把新模組改成「設空而非刪除」→ 2 個測試紅；改成「cli 也要求憑證」→ 1 個測試紅。測試確實抓得到回歸，不是擺設
- **端到端實跑 `claude-agent-sdk`**：在刻意殘留 `base_url` 與假 token 的環境下，cli 模式清乾淨並成功取得模型回應，全程無 OpenRouter 憑證

```
已移除 ANTHROPIC_BASE_URL、ANTHROPIC_AUTH_TOKEN、ANTHROPIC_API_KEY
忽略 gateway 格式的模型名稱 'anthropic/claude-sonnet-4.6'，改用 'sonnet'
殘留變數 = {全部 None}
LLM 回應 → 本機直連
```

- 第七道檢查以兩種佔位形狀實測會紅燈，還原後綠
- `docker compose config` 確認 `LLM_PROVIDER: openrouter` 有傳進容器
- repo/env contract、OpenAPI 漂移、`render-env.sh` 與 YAML 語法皆通過

## 文件

`LOCAL-DEV.md` 的 H1 依賴段落改寫。順帶更正一個原本寫錯的前提：SDK 自帶一份 `claude` 執行檔（`claude_agent_sdk/_bundled/claude`），所以**不一定**要全域安裝 `@anthropic-ai/claude-code`——但**登入不是自帶的**，仍需先跑過 `claude login`。

## 部署影響

無。`LLM_PROVIDER` 在 `render-env.sh` 與 `deploy/.env.example` 都寫死 `openrouter`，compose 也以無 fallback 的形式消費它（讓 env contract 強制三者同步）。容器沒有互動式登入，`cli` 模式本來就不適用。

## 追加：本機實跑後補上的兩個修正

上面的驗證是在**乾淨環境**跑的。實際拿一台留著 OpenRouter 殘值的機器跑起來，才露出兩個缺陷。

### 1. `cli` 模式漏刪 `ANTHROPIC_DEFAULT_*_MODEL`（commit 2511e3d）

模型正規化與變數刪除互相抵銷：

```
LLM_PROVIDER=cli + .env 殘留 ANTHROPIC_DEFAULT_SONNET_MODEL
→ claude -p ... --model sonnet
→ 404 There's an issue with the selected model (anthropic/claude-sonnet-4.6)
```

那一族變數定義 CLI 的**別名**指向哪個實際模型，不是「要用哪個模型」。所以 `get_model_name()` 把殘留的 slug 正規化成 `sonnet` 之後，子行程又照著它映射回原本的 slug。它會漏掉是因為它既不認證也不路由——不在「哪些變數會蓋掉 CLI 登入」的心智模型裡，前述 21 個測試也因此全部繞過它。

`openrouter` 與部署路徑不變：該變數在 gateway 下確實是模型來源，仍由 `_configure_openrouter_env()` 寫入。

### 2. 圖示比對查無對應時給出錯誤圖示（commit 806d5d0）

把 `N8N_WEBHOOK_URL` 從舊範本的佔位字串改成真值後，圖示第一次真的回來，也才看得到被「全部灰底」蓋住的問題：比對全滅時退回 `data[0]`（目錄第一項是 `Auto-Scaling-group`），且**無 log**。實測 315 項目錄裡沒有任何 `icon_name` 含 `SNS` 或 `KMS`——它們叫 `Simple Notification Service`、`AWS Key Management Service`。`S3` 唯一的子字串命中是 `S3 on Outposts`。

改為：純函式化的正規化／評分／挑選，14 條經目錄驗證的縮寫對照，查無對應一律回灰底並記 WARNING，HTTP 非 200 也補上 log。

### 追加驗證

- **212 個測試通過**（累計新增 25 個）
- **突變測試 6 項皆紅燈**（本輪追加的，不含原有兩項）：只刪認證三個變數、cli 也讀別名變數、退回 `entries[0]`、縮寫展開失效、恢復反方向子字串、非 200 不記 log
- **對真實 n8n webhook 驗證**：15 個 AWS 服務全部挑到正確目錄項，4 個非 AWS 服務全部落到灰底並記 log
- repo/env contract 皆通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

