### PR TITLE
文件(sync): ADR-0012 與實作藍圖，AI-DLC ↔ GitHub 雙向同步

### DIFF
--- a/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
+++ b/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
@@ -156,7 +156,27 @@ Wiki 是**單向鏡像**（repo → Wiki），不回寫。Wiki 頁首自動加�
 |---|---|---|
 | **1** | repo → Issues 單向：intent 的 stories 建立／更新 issue（受管區塊） | 一個 intent 的所有 story 在 GitHub 有對應 issue，重跑不產生重複 |
 | **2** | Issues → repo 反向：狀態（open/closed、assignee、labels）定時拉回，開 PR | 在 GitHub 關掉 issue，下次同步產生一個更新 `aidlc-state.md` 的 PR |
+| **2.5** | **bug 路徑 B（半自動）**：列出待修 bug，人選一個帶入 `/aidlc --scope bugfix` | 從 issue 挑一個 bug 到產出帶 `Closes #N` 的 PR，全程可在本機完成 |
 | **3** | Projects v2：intent → Project、看板欄位 ↔ 階段狀態、Bolt → iteration | 看板反映真實進度；拖動卡片會回寫 repo |
+| **3.5** | **bug 路徑 A（自動）**：`aidlc:auto` label 觸發，自架 runner 跑完並開 PR | 貼 label 後不需人介入即產出 PR，且 PR 說明揭露未經 stage gate |
 | **4** | Wiki 單向鏡像 | 已核可 artifacts 與根層文件出現在 Wiki，頁首帶來源警語 |
 
 階段 1 完成前不啟用階段 2 —— 沒有穩定的正向同步，反向同步沒有比對基準。
+階段 2.5 先於 3.5 —— 半自動只用本機既有環境，自動路徑要先在自架 runner 上備妥 `bun`、`claude` CLI 與 LLM 憑證。先讓 issue → intent 的轉換被人工驗證過，再投資 CI 基礎設施。
+
+#### 外部進入點：GitHub 上回報的 bug
+
+`bugfix` scope 的 8 個 stage **不含 `user-stories`**，因此走 bugfix 的 intent 不產生 stories，Decision 第 1 點的 story → Issue 映射對它不適用。**bug issue 本身就是工作項**，不再產生第二則 issue 代表同一件事。
+
+bug issue 是**回報者寫的**，因此：**不加受管區塊、內文永不被覆寫**。同步只做三件事——加進 Project 看板、在三個節點留言（已接受／PR 已開／合併時由 `Closes #N` 自動關）、以及 PR 合併後關閉。
+
+兩條路徑並存，差別**只有 gate 的位置**：
+
+| | 路徑 A（自動，label 觸發） | 路徑 B（半自動，終端機挑） |
+|---|---|---|
+| stage approval gate | **跳過** | 完整執行 |
+| PR review | 有 | 有 |
+
+**路徑 A 的 PR 必須在說明中揭露「本 PR 由自動路徑產生，未經 stage approval gate」。** 這是 reviewer 判斷該用多少力氣審的依據；少了它，自動路徑就是繞過方法論的後門。兩條路徑都以 PR 為最終關卡，PR 不自動合併，人的決定權完整保留。
+
+此分界與 repo 既有實務一致：`deploy-doctor` 只診斷不修（明文寫「so a human can fix」），`lint-fix` 自動修但僅限機械性、零判斷的問題。bug 修復介於兩者之間，故保留自動路徑但把 gate 明確移到 PR。

--- a/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
+++ b/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
@@ -98,6 +98,33 @@ Wiki 是**單向鏡像**（repo → Wiki），不回寫。Wiki 頁首自動加�
 - 反向同步（GitHub → repo）**一律開 PR，不直接推 `ut`**。人審過才進 trunk，保住 approval gate 的精神。
 - Projects token 存為獨立 secret，不重用既有的。
 
+#### 6. 與 AI-DLC 主流程零耦合（硬約束）
+
+**同步機制不得修改 AI-DLC 主流程，也不得在 `.claude/` 下新增任何檔案。**
+
+這條的由來是升級韌性：upstream 升級的動作是「把 `dist/claude/` 重新複製到 `.claude/`」，任何放在該目錄下的東西都在覆蓋範圍內。
+
+查證後確認 **AI-DLC 的 plugin 機制不提供檔案系統層級的隔離**：
+
+- `harness.json` 的 `plugins` 欄位只是一個**啟用 allowlist**，決定哪些 plugin 的 stage 生效。
+- 沒有任何工具會從 `plugins/<name>/` 安裝東西；stage 檔仍然**只能**放在 `.claude/aidlc-common/stages/<phase>/`（`aidlc-graph.ts` 的 `stagesDir()` 只掃這一個目錄，`AIDLC_STAGES_DIR` 是測試 seam 而非安裝點）。
+- 因此 `plugin:` 欄位給的是**邏輯**歸屬（標記擁有者、可整組停用），不是升級隔離。本 repo 的 `tcms-test-cases` 就是實例：它是 plugin stage，仍然得靠 repo contract 與 `README-cloud360.md` 登記才不會在升級時無聲消失。
+
+所以「做成 plugin」**不足以**達成升級韌性。真正有效的做法是**完全不進 `.claude/`**：
+
+| 元件 | 位置 | 升級影響 |
+|---|---|---|
+| 同步 workflows | `.github/workflows/aidlc-sync-*.md` | 無 —— upstream 不碰 `.github/` |
+| 同步腳本 | `scripts/aidlc_sync_*.py` | 無 |
+| 同步狀態 | `<record>/.aidlc-sync-state.json` | 無 —— `aidlc/` 工作區永不被覆蓋 |
+| 規則與說明 | `aidlc/spaces/*/memory/project.md` | 無 |
+
+**觸發方式是 git push，不是 AI-DLC 的 stage 或 hook。** AI-DLC 產出 artifact 並 commit 之後，`on: push` 的 paths 過濾自然觸發同步。AI-DLC 對此一無所知，也不需要知道。這讓同步機制與框架版本完全解耦：升級 AI-DLC 不影響同步，停用同步不影響 AI-DLC。
+
+代價是**同步的時機是「commit 之後」而不是「stage 完成的當下」**。實務上兩者相差一次 commit，而 AI-DLC 的 artifact 本來就要進版控才算數，這個延遲沒有實際損失。
+
+若未來真的需要 stage 內的即時掛鉤（例如 stage 一完成就更新 Project 欄位而不等 commit），那才評估新增 plugin stage，且屆時必須比照 `tcms-test-cases` 的既有機制：列入 `REQUIRED_FILES`、登記於 `README-cloud360.md` 的升級步驟。**在那之前，不碰 `.claude/`。**
+
 ### Consequences
 
 - **協作者不必讀 repo 就能看到進度**，這是本 ADR 的目的。代價是多一套需要維護的同步機制。
@@ -107,6 +134,7 @@ Wiki 是**單向鏡像**（repo → Wiki），不回寫。Wiki 頁首自動加�
 - **Wiki 是第二份副本**。即使有「請勿直接編輯」的警語，仍會有人編輯而後被覆蓋。單向設計讓資料不會遺失到無法追溯（Wiki 有自己的 git 歷史），但體驗上會是「我的修改不見了」。
 - **既有的 `spec-sync` 與 `issue-triage` 需要重審**：新機制會建立大量帶 `aidlc` 標籤的 issue，`issue-triage` 對它們的分類行為要排除或特化，否則會互相干擾。
 - **200+ 既有 issue 不回溯**。同步只作用於本 ADR 之後的 intent；歷史 issue 維持原狀。
+- **升級 AI-DLC 不會影響同步，這是刻意換來的**（第 6 點）。代價是同步時機為 commit 之後而非 stage 完成的當下，且無法取得 stage 內部的中間狀態——同步看得到的只有進版控的 artifact。若日後證明這個粒度不夠，才需要重新評估是否值得為此新增 plugin stage 並承擔升級維護成本。
 
 ### Alternatives
 
@@ -115,6 +143,8 @@ Wiki 是**單向鏡像**（repo → Wiki），不回寫。Wiki 頁首自動加�
 **B. GitHub 永遠贏，repo 跟隨。** 符合「GitHub 是團隊的協作中心」的直覺。否決原因：直接摧毀 approval gate——經人工核可的驗收標準會被任何有 issue 權限的人改掉，且 AI-DLC 的下一階段會照著改過的內容繼續推進，沒有任何地方會發出聲音。
 
 **C. 偵測到雙邊修改就開 issue 請人決定。** 最安全，不會遺失資料。否決原因：狀態欄位的雙邊修改是**常態**而非例外（人拖卡片的同時 AI-DLC 正在推進階段），衝突 issue 會迅速變成新的噪音來源，重演 `daily-digest` 淹沒 issue 列表的情況。逐欄位切分讓常態不成為衝突，只有真正罕見的情況才需要人介入。
+
+**E. 做成 AI-DLC plugin stage（在流程內同步）。** 直覺上最「正統」：同步是流程的一環，就該是 stage。否決原因有二。其一，**plugin 不提供升級隔離**——stage 檔仍須放在 `.claude/aidlc-common/stages/`，upstream 升級照樣覆蓋；`plugin:` 欄位只是啟用開關與歸屬標記（見 Decision 第 6 點的查證）。其二，**同步不需要流程內的資訊**：它要的是 artifact 的最終內容，而 artifact 進版控本來就是流程的完成條件，`on: push` 拿得到一模一樣的東西。付出升級維護成本卻換不到額外能力。保留為未來選項：若出現「必須在 commit 之前取得 stage 中間狀態」的真實需求，再重新評估。
 
 **D. 不做 Wiki，只做 Issues／Projects。** 合理的減法，GitHub 本來就能直接瀏覽 repo 內的 markdown。保留為可退回的選項：若 Wiki 的維護成本高於價值，階段 4 可以直接取消而不影響前三階段。
 

--- a/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
+++ b/aidlc/spaces/default/intents/260802-default/inception/decisions/0012-github-issues-projects-wiki-sync.md
@@ -1,0 +1,132 @@
+# ADR 0012: AI-DLC 與 GitHub Issues／Projects／Wiki 的雙向同步
+
+- Status: Accepted（設計；實作分階段，見「分階段落地」）
+- Date: 2026-08-16
+- Related: ADR-0011（採用 AI-DLC v2）、ADR-0008（Construction↔Operations 連續模型）、ADR-0009（文件一律繁體中文）、`.github/workflows/spec-sync.md`、`.github/workflows/issue-triage.md`
+
+### Context
+
+AI-DLC 的工作狀態目前**只存在於 repo 內**：intent 的進度在 `<record>/aidlc-state.md`，需求在 `stories.md`，實作單元在 `unit-of-work.md`，決策在 `decisions/`。這對走 AI-DLC 流程的人夠用，但有兩個實際問題：
+
+1. **協作者看不到進度**。不看 repo 的人（PM、QA、其他團隊）無從得知某個需求做到哪、誰在做、卡在哪。GitHub 的 Issues 與 Projects 正是為此存在，但目前完全沒有承載 AI-DLC 的內容。
+2. **在 GitHub 上做的事回不到 repo**。有人在 issue 上補充需求、在看板上拖動卡片、在 Wiki 上修文件，AI-DLC 這邊一無所知，下一輪流程會用過期的認知繼續推進。
+
+現況盤點（2026-08-16）：
+
+- **既有 11 個 gh-aw workflows**，其中兩個已觸及此領域：`spec-sync`（spec 變更 → 開 issue 列出要改的 code）與 `issue-triage`（新 issue → 分類、貼標籤、問缺的細節）。兩者都是**單向且唯讀**（`permissions: issues: read`），寫入透過 gh-aw 的 safe-outputs 由框架代理。
+- **Issues 有 200+ 筆**，絕大多數是 `daily-digest` 每日自動產生的。同步進來的 issue 會混在這個池子裡。
+- **Wiki `has_wiki=true` 但 wiki 的 git repo 不存在** —— 從未初始化。GitHub 要先手動建立第一頁，`<repo>.wiki.git` 才會生成。
+- **Projects 已啟用**，尚未有 AI-DLC 內容。
+
+技術約束（實測確認）：
+
+- **gh-aw 的 `safe-outputs` 只支援 `create-issue`／`close-issue`／`add-comment`／`add-labels`／`push-to-pull-request-branch`。** 沒有「更新 issue 標題或內文」，沒有 Projects 操作，沒有 Wiki 操作。這是 gh-aw 刻意的安全設計：agent 不持有寫入權限，寫入由框架以受限的形狀代理。
+- 因此「自動增刪**修**議題內容及狀態」與 Projects 同步**無法只靠 safe-outputs 完成**，必須提權讓 workflow 直接呼叫 `gh` CLI／GraphQL。
+
+方法論約束：
+
+- AI-DLC 的 artifacts 有 **approval gate**。`stories.md` 的驗收標準是經過人工核可的產物，`decisions/` 是架構決策紀錄。
+- 本專案已在 `test-case-management-plan.md` 與 `TESTING.md` 建立「**每種資料只能有一個真實來源**」的紀律。雙向同步天然與這條紀律衝突，除非把真實來源切得夠細。
+
+### Decision
+
+#### 1. 分層映射
+
+| AI-DLC | GitHub | 依據 |
+|---|---|---|
+| intent（`intents.json` 的一列） | **Project (v2)** 一個 | intent 是一整個需求的生命週期，對應看板剛好 |
+| user story（`stories.md` 的 `## US-n`） | **Issue** 一則 | story 是可分派、可討論、可驗收的最小需求單位 |
+| unit of work（`unit-of-work.md`） | Issue 的 **子任務**（task list item） | 實作單元屬於某個 story，不該與 story 平級競爭注意力 |
+| Bolt（`bolt-plan.md`） | Project 的 **iteration 欄位** | Bolt 是交付批次，是看板的時間維度而非工作項 |
+| 已核可 artifacts + 根層文件 | **Wiki 頁面** | 見第 3 點 |
+
+同步進來的 issue 一律帶 `aidlc` 標籤與 `intent:<slug>` 標籤，與 `daily-digest` 產生的噪音區隔開。
+
+#### 2. 真實來源逐欄位切分
+
+這是本 ADR 的核心決定。**不是整個物件歸誰，是每個欄位歸誰**：
+
+| 欄位類 | 真實來源 | 理由 |
+|---|---|---|
+| **狀態**：open/closed、看板欄位、assignee、labels、iteration | **GitHub** | 人在看板上拖卡片、指派、關閉 issue，本來就是正式操作。要求他們改 repo 才算數，等於否定看板的存在意義 |
+| **內容**：story 標題與敘述、驗收標準、unit 定義、決策內文 | **repo** | 這些經過 AI-DLC 的 approval gate。若任何人在 issue 上改 AC 就能覆寫回 repo，那個 gate 形同虛設 |
+| **討論**：issue comments | **GitHub**（單向，不回寫 repo） | 討論是過程，不是 artifact。要納入 artifact 必須經由 AI-DLC 流程重新產出 |
+
+於是同步是**非對稱**的：
+
+```
+repo  ──內容──▶  GitHub      （AI-DLC 流程觸發，覆寫 issue 內文的受管區塊）
+repo  ◀──狀態──  GitHub      （定時 workflow 拉取，寫回 aidlc-state.md 與 intents.json）
+```
+
+**issue 內文分兩區**：`<!-- aidlc:managed -->` 與 `<!-- /aidlc:managed -->` 之間由 repo 覆寫；標記之外的內容是人寫的，同步永不觸碰。這讓「內容 repo 贏」不至於吃掉協作者在 issue 上補充的脈絡。
+
+#### 3. Wiki 只放已核可的成品
+
+同步範圍限定：
+
+- **已核可 artifacts**：SRS、architecture、ADR、user stories
+- **根層文件**：`README.md`、`DEPLOY.md`、`LOCAL-DEV.md`、`TESTING.md`
+
+不同步中間過程文件（各 stage 的 questions、memory diary、reviewer contributions）——它們是流程的工作痕跡，對 Wiki 的讀者是噪音。
+
+Wiki 是**單向鏡像**（repo → Wiki），不回寫。Wiki 頁首自動加註「本頁由 `<來源路徑>` 自動同步，請勿直接編輯」。這與第 2 點的「內容 repo 贏」一致，也避開了 Wiki 沒有 PR review 的問題。
+
+> Wiki 必須先在 GitHub UI 手動建立第一頁，`<repo>.wiki.git` 才存在。這是實作的前置條件。
+
+#### 4. 防迴圈
+
+雙向同步的必然風險：repo 寫 GitHub → 定時任務讀回 → 寫 repo → 觸發 workflow → 又寫 GitHub。三道防線：
+
+1. **內容雜湊比對**：同步前先算受管區塊的雜湊，與上次同步記錄的雜湊相同就跳過寫入。
+2. **來源標記**：所有由同步產生的 commit 訊息帶 `[aidlc-sync]`；反向同步的觸發條件排除這類 commit。
+3. **狀態欄位單向**：狀態只從 GitHub 流向 repo，repo 不寫 GitHub 的狀態欄位（除了建立 issue 時的初始值）。單向的欄位不可能來回震盪。
+
+同步狀態記錄於 `<record>/.aidlc-sync-state.json`（gitignored 的 per-clone 檔不適用——這需要進版控才能跨 runner 比對，因此放在 record 內並隨同步 commit 一起更新）。
+
+#### 5. 權限：明確提權，範圍最小
+
+`safe-outputs` 不足以完成「修改」與 Projects 操作，因此同步 workflow 需要：
+
+- `issues: write`（更新 issue 內文與 labels）
+- `contents: write`（回寫 repo 的狀態與 Wiki 推送）
+- Projects v2 需要 **classic PAT 或 GitHub App token**（`GITHUB_TOKEN` 不涵蓋 Projects v2 的 GraphQL 寫入）
+
+這是對既有安全模型的**實質放寬**，因此：
+
+- 同步 workflow **與其他 agentic workflow 分離**，不共用 token。
+- 反向同步（GitHub → repo）**一律開 PR，不直接推 `ut`**。人審過才進 trunk，保住 approval gate 的精神。
+- Projects token 存為獨立 secret，不重用既有的。
+
+### Consequences
+
+- **協作者不必讀 repo 就能看到進度**，這是本 ADR 的目的。代價是多一套需要維護的同步機制。
+- **內容仍受 approval gate 保護**：在 issue 上改 AC 不會回寫 repo。這會讓習慣「在 issue 上討論就算數」的人感到摩擦——受管區塊的警語與 PR 化的反向同步是唯一的緩衝。
+- **權限被實質放寬**。這是本 ADR 最大的風險項：一個能寫 issues 與 contents 的 agentic workflow，比目前任何一個既有 workflow 都有更大的作用面。反向同步 PR 化是主要的補償控制。
+- **Projects v2 需要額外 token**，且它的 GraphQL API 與 REST 不同，實作成本高於 Issues。這是把 Projects 排在階段 3 的原因。
+- **Wiki 是第二份副本**。即使有「請勿直接編輯」的警語，仍會有人編輯而後被覆蓋。單向設計讓資料不會遺失到無法追溯（Wiki 有自己的 git 歷史），但體驗上會是「我的修改不見了」。
+- **既有的 `spec-sync` 與 `issue-triage` 需要重審**：新機制會建立大量帶 `aidlc` 標籤的 issue，`issue-triage` 對它們的分類行為要排除或特化，否則會互相干擾。
+- **200+ 既有 issue 不回溯**。同步只作用於本 ADR 之後的 intent；歷史 issue 維持原狀。
+
+### Alternatives
+
+**A. repo 永遠贏，GitHub 純鏡像。** 最簡單、無衝突、無迴圈。否決原因：等於告訴協作者「不要在 GitHub 上改任何東西」，而看板的價值正是讓人在上面操作。拖動卡片會被下次同步彈回原位，這比沒有同步更糟。
+
+**B. GitHub 永遠贏，repo 跟隨。** 符合「GitHub 是團隊的協作中心」的直覺。否決原因：直接摧毀 approval gate——經人工核可的驗收標準會被任何有 issue 權限的人改掉，且 AI-DLC 的下一階段會照著改過的內容繼續推進，沒有任何地方會發出聲音。
+
+**C. 偵測到雙邊修改就開 issue 請人決定。** 最安全，不會遺失資料。否決原因：狀態欄位的雙邊修改是**常態**而非例外（人拖卡片的同時 AI-DLC 正在推進階段），衝突 issue 會迅速變成新的噪音來源，重演 `daily-digest` 淹沒 issue 列表的情況。逐欄位切分讓常態不成為衝突，只有真正罕見的情況才需要人介入。
+
+**D. 不做 Wiki，只做 Issues／Projects。** 合理的減法，GitHub 本來就能直接瀏覽 repo 內的 markdown。保留為可退回的選項：若 Wiki 的維護成本高於價值，階段 4 可以直接取消而不影響前三階段。
+
+### 分階段落地
+
+實作分四階段，每階段可獨立驗收、可獨立回退：
+
+| 階段 | 範圍 | 出口條件 |
+|---|---|---|
+| **1** | repo → Issues 單向：intent 的 stories 建立／更新 issue（受管區塊） | 一個 intent 的所有 story 在 GitHub 有對應 issue，重跑不產生重複 |
+| **2** | Issues → repo 反向：狀態（open/closed、assignee、labels）定時拉回，開 PR | 在 GitHub 關掉 issue，下次同步產生一個更新 `aidlc-state.md` 的 PR |
+| **3** | Projects v2：intent → Project、看板欄位 ↔ 階段狀態、Bolt → iteration | 看板反映真實進度；拖動卡片會回寫 repo |
+| **4** | Wiki 單向鏡像 | 已核可 artifacts 與根層文件出現在 Wiki，頁首帶來源警語 |
+
+階段 1 完成前不啟用階段 2 —— 沒有穩定的正向同步，反向同步沒有比對基準。

--- a/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
+++ b/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
@@ -89,7 +89,63 @@ AI-DLC 產出 artifact → commit → push → `on: push` 的 paths 過濾觸發
 | assignee | — | **GH → repo** |
 | comments | — | 不同步（只在 GitHub） |
 
-### 1.3 unit of work → Issue 的子任務
+### 1.3 從 AI-DLC 流程看：什麼時候會動到 GitHub
+
+**AI-DLC 流程本身零改動。** 33 個 stage 一個都不新增、不修改、不重排；沒有新 hook、沒有改 `settings.json`。同步只發生在「artifact 進版控之後」。
+
+33 個 stage 裡，**只有 5 個的產出會觸發內容同步**；其餘 28 個對 GitHub 的內容毫無影響：
+
+| Phase | Stage | 產出 | GitHub 上發生什麼 |
+|---|---|---|---|
+| inception | `requirements-analysis` | `requirements` | Wiki 新增／更新需求頁 |
+| inception | `user-stories` | `stories` | **每個 `US-n` 建立或更新一則 Issue**（受管區塊） |
+| inception | `application-design` | `decisions`（ADR） | Wiki 新增／更新 ADR 頁 |
+| inception | `units-generation` | `unit-of-work` | 對應 story 的 Issue 內，task list 增減項目 |
+| inception | `delivery-planning` | `bolt-plan` | Project 的 iteration 欄位建立／更新 |
+
+另有一項與 stage 無關、但**每個 stage 完成時都會發生**：
+
+| 觸發 | 來源 | GitHub 上發生什麼 |
+|---|---|---|
+| 任一 stage 完成 | `aidlc-state.md` 的 `Current Stage` / `Phase Progress` 更新 | Project 卡片的 **Status 欄位**移動到對應 phase |
+
+也就是說，**看板上的卡片會隨流程推進自己移動**（ideation → inception → construction → operation），而 Issue 的內容只在上表那 5 個 stage 才變。這正是「狀態」與「內容」分屬不同真實來源的體現：狀態頻繁變動、內容經 gate 才變。
+
+### 1.3.1 一個 intent 的完整時序
+
+以 `feature` scope 為例，從頭到尾 GitHub 上依序看到的東西：
+
+```
+ideation（7 stages）
+  └─ 每個 stage 完成 → Project 卡片停在「Ideation」欄
+     GitHub 上還沒有任何 Issue —— 此時需求尚未成形，開 issue 只會是雜訊
+
+inception
+  ├─ requirements-analysis → Wiki 出現需求頁
+  ├─ user-stories          → ★ Issues 大量出現（每個 US-n 一則）
+  │                           卡片移到「Inception」欄
+  ├─ application-design    → Wiki 出現 ADR 頁
+  ├─ units-generation      → 既有 Issue 的 task list 被填入實作單元
+  └─ delivery-planning     → Project 出現 iteration（Bolt 1、Bolt 2…）
+
+construction（8 stages，含 tcms-test-cases）
+  └─ 每個 stage 完成 → 卡片移到「Construction」欄
+     Issue 內容不再變動（除非回頭修 stories 或 units）
+     人在此期間勾 task list、關閉 issue、指派 assignee ← 這些會被反向同步拉回
+
+operation（7 stages）
+  └─ 卡片移到「Operation」欄
+```
+
+**Issue 出現的時機是 `user-stories` 完成之後**，不是 intent 一開始。ideation 階段的產出（intent statement、scope、feasibility）刻意不同步——那時需求還在成形，開 issue 只會製造需要回頭清理的雜訊。
+
+### 1.3.2 反向同步與 stage 無關
+
+反向同步（GitHub → repo）是**定時**的（每 6 小時），不掛在任何 stage 上。它在 intent 的任何階段都可能發生，包括 AI-DLC 完全沒在跑的時候——人在週末拖了卡片，週一的第一次同步就會產生 PR。
+
+這是刻意的：協作者的操作不該等 AI-DLC 跑到某個 stage 才被承認。
+
+### 1.4 unit of work → Issue 的子任務
 
 `unit-of-work.md` 的每個單元渲染成受管區塊內的 task list：
 

--- a/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
+++ b/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
@@ -10,7 +10,47 @@
 
 ---
 
-## 0. 前置條件（實作前必須先完成）
+## 0. 隔離邊界（最重要的實作約束）
+
+**同步機制的任何檔案都不得放進 `.claude/`。** 依據見 [ADR-0012 Decision 第 6 點](../inception/decisions/0012-github-issues-projects-wiki-sync.md)：upstream 升級會把 `dist/claude/` 整批複製到 `.claude/`，而 AI-DLC 的 plugin 機制**不提供**檔案系統層級的隔離（`plugin:` 只是啟用開關，stage 檔仍須放在 upstream 目錄）。
+
+允許動到的位置，全部在升級範圍之外：
+
+```
+.github/workflows/aidlc-sync-*.md        同步 workflow（gh-aw 來源）
+.github/workflows/aidlc-sync-*.lock.yml  gh aw compile 的產物
+scripts/aidlc_sync_*.py                  解析與渲染的實作
+<record>/.aidlc-sync-state.json          同步狀態（進版控）
+aidlc/spaces/*/memory/project.md         規則層的一條說明
+```
+
+**禁止動到**：`.claude/` 下的任何路徑（stages、hooks、skills、tools、settings.json）。
+
+### 升級韌性的驗收方式
+
+不是宣稱，是可執行的檢查。實作完成後跑一次：
+
+```bash
+# 1. 同步機制沒有任何檔案落在 .claude/
+git log --oneline --name-only -20 -- .claude/ | grep -i sync   # 應無輸出
+
+# 2. 模擬升級：暫時移走 .claude/ 的 stage 與 hook，同步腳本仍可獨立執行
+mv .claude /tmp/claude-backup
+python3 scripts/aidlc_sync_push.py --dry-run                    # 應正常執行
+mv /tmp/claude-backup .claude
+```
+
+第 2 項是關鍵：**同步腳本不得 import 或讀取 `.claude/` 下的任何東西**。它讀的是 `aidlc/` 工作區的 artifact（那是永不被覆蓋的區域）與 GitHub API。
+
+### 觸發方式：git push，不是 stage
+
+AI-DLC 產出 artifact → commit → push → `on: push` 的 paths 過濾觸發同步。AI-DLC 對同步一無所知。
+
+代價是同步時機為「commit 之後」而非「stage 完成的當下」。artifact 本來就要進版控才算數，所以這個延遲沒有實際損失。
+
+---
+
+## 0.1 前置條件（實作前必須先完成）
 
 | # | 項目 | 怎麼做 | 沒做會怎樣 |
 |---|---|---|---|

--- a/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
+++ b/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
@@ -310,7 +310,91 @@ clone `<repo>.wiki.git` → 渲染（頁首加來源警語與原始路徑連結�
 
 ---
 
-## 7. 開放問題（實作前要有答案）
+## 7. 外部進入點：GitHub 上回報的 bug
+
+前面幾節處理的是 **AI-DLC → GitHub** 的產出同步。bug 的方向相反：它從 GitHub 進來，是外部進入點。
+
+### 7.1 bug 不套用 story → Issue 映射
+
+查證 stage graph 後確認：**`bugfix` scope 的 8 個 stage 裡沒有 `user-stories`**。
+
+```
+workspace-scaffold → workspace-detection → state-init → reverse-engineering
+→ requirements-analysis → code-generation → build-and-test → tcms-test-cases
+```
+
+走 bugfix 的 intent 根本不產生 stories，所以 §1.2 的映射對它不適用。**bug issue 本身就是那個工作項**，AI-DLC 不該再產生第二則 issue 代表同一件事——那是重複，且會讓回報者的原 issue 變成孤兒。
+
+### 7.2 兩類 issue 的所有權必須分清
+
+| | 來源 | 受管區塊 | 內容誰的 |
+|---|---|---|---|
+| story issue | AI-DLC 產生 | 有 | repo 覆寫受管區塊 |
+| **bug issue** | **人寫的** | **不得加** | **完全屬於回報者，永不覆寫** |
+
+同步機制**永遠不寫 bug issue 的內文**。它只做三件事：加進 Project 看板、在關鍵節點留言、由 PR 的 `Closes #N` 關閉。
+
+### 7.3 兩條路徑
+
+**路徑 A — 自動（在 GitHub 上跑完）**
+
+```
+人貼 aidlc:auto label
+  → workflow 觸發，在自架 runner 上跑 bugfix 流程
+  → 產出修正 code + 測案 + AI-DLC record
+  → 開 PR（帶 Closes #N）
+  → 在 issue 留言「已接受、PR #M 已開」
+  → 人 review 並合併  ← gate 在這裡
+  → issue 自動關閉
+```
+
+**路徑 B — 半自動（人在終端機挑）**
+
+```
+人跑 scripts/aidlc_sync_buglist.py    列出待修的 bug（label=bug 且未被接受）
+  → 選一個
+  → /aidlc --scope bugfix（自動帶入該 issue 的標題與內文）
+  → 正常的 AI-DLC 流程，含每個 stage 的 approval gate
+  → 產出 PR（帶 Closes #N）
+  → 同樣的留言與關閉機制
+```
+
+### 7.4 兩條路徑的差別只有一個：gate 在哪
+
+| | 路徑 A（自動） | 路徑 B（半自動） |
+|---|---|---|
+| stage approval gate | **跳過** | 完整執行 |
+| PR review | 有 | 有 |
+| 適用 | 有明確重現步驟、影響面清楚的 bug | 需要判斷範圍或牽動設計的 bug |
+
+**路徑 A 的 PR 必須在說明中揭露「本 PR 由自動路徑產生，未經 stage approval gate」。** 這句話不是形式——它是 reviewer 判斷該用多少力氣審的依據。少了它，自動路徑就成了繞過方法論的後門。
+
+這條分界線與 repo 既有的自動化實務一致：`deploy-doctor` 只診斷不修（「so a human can fix」），`lint-fix` 會自動修但只限機械性、零判斷的 lint 問題。bug 修復介於兩者之間，所以保留自動路徑，但把 gate 明確地移到 PR。
+
+### 7.5 進度回報：三個節點，不多不少
+
+只在這三個時機於 issue 留言：
+
+1. **已接受** —— intent 建立時：「已建立 bugfix intent `<slug>`，走路徑 A／B」
+2. **修正 PR 已開** —— PR 編號與一句摘要
+3. **已合併** —— 由 `Closes #N` 自動關閉時（GitHub 原生行為，不需額外留言）
+
+bugfix scope 有 8 個 stage，若每個 stage 都留言會產生 8 則機器留言，把回報者的討論淹掉。細部進度看 Project 卡片。
+
+### 7.6 技術前置（路徑 A 專屬）
+
+路徑 A 要在 CI 裡跑 AI-DLC，不是跑 gh-aw 的 copilot engine：
+
+| 需求 | 說明 |
+|---|---|
+| 執行環境 | 自架 runner（`[self-hosted, linux, x64, cloud360]`），需裝 `bun` 與 `claude` CLI |
+| LLM 憑證 | runner 上的 `claude` CLI 需可認證（`LLM_PROVIDER` 的兩種模式擇一） |
+| 權限 | `contents: write`（推分支）、`pull-requests: write`（開 PR）、`issues: write`（留言與標籤） |
+| 隔離 | 同 §0：workflow 與腳本都不進 `.claude/` |
+
+**路徑 B 沒有這些前置**——它在開發者自己的機器上跑，用的是既有的本機環境。所以實作順序是 **B 先於 A**：先讓半自動可用，確認 issue → intent 的轉換正確，再投資自動路徑的 CI 基礎設施。
+
+## 8. 開放問題（實作前要有答案）
 
 1. **一個 intent 的 stories 改名或刪除時**，對應的 issue 怎麼處理？關閉並加 `wontfix`？還是留著？（傾向：關閉並在受管區塊註記「此 story 已從需求移除」，不刪 issue——issue 編號是外部引用點。）
 2. **`daily-digest` 每天產生 issue** 已使 issue 列表達 200+ 筆。是否該讓 digest 改用 discussion 或直接關閉舊的？這會影響同步進來的 issue 的可見度。

--- a/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
+++ b/aidlc/spaces/default/intents/260802-default/operation/github-sync-design.md
@@ -1,0 +1,222 @@
+# GitHub 同步實作藍圖 — Cloud-360
+
+- Status: Design（ADR-0012 已 Accepted；實作尚未開始）
+- Date: 2026-08-16
+- 決策依據：[ADR-0012](../inception/decisions/0012-github-issues-projects-wiki-sync.md)
+- 關聯：`.github/workflows/spec-sync.md`、`.github/workflows/issue-triage.md`、`test-case-management-plan.md`
+
+> 本檔是 ADR-0012 的實作細節。ADR 說**為什麼這樣設計**，本檔說**怎麼做**。
+> 兩者有出入時以 ADR 為準。
+
+---
+
+## 0. 前置條件（實作前必須先完成）
+
+| # | 項目 | 怎麼做 | 沒做會怎樣 |
+|---|---|---|---|
+| P1 | **初始化 Wiki** | 在 GitHub UI 建立第一頁（任意內容） | `<repo>.wiki.git` 不存在，階段 4 無法 clone |
+| P2 | **Projects v2 token** | 建立 GitHub App 或 classic PAT，scope `project`；存為 secret `GH_PROJECTS_TOKEN` | 階段 3 的 GraphQL 寫入全部 401；`GITHUB_TOKEN` **不涵蓋** Projects v2 |
+| P3 | **本機 gh scope** | `gh auth refresh -s read:project,project` | 開發時無法查證看板現況 |
+| P4 | **建立 label** | `aidlc`、`intent:<slug>`、`story`、`sync-conflict` | issue 混在 200+ 筆 digest 噪音中無法篩選 |
+| P5 | **確認 `issue-triage` 的排除規則** | 讓它跳過帶 `aidlc` 標籤的 issue | 兩個 workflow 互相改標籤，來回震盪 |
+
+---
+
+## 1. 映射細節
+
+### 1.1 intent → Project
+
+| Project 欄位 | 來源 | 方向 |
+|---|---|---|
+| Project 名稱 | `intents.json` 的 `slug` | repo → GH（建立時） |
+| Project 描述 | `<record>/aidlc-state.md` 的 intent 摘要 | repo → GH |
+| Status 欄位選項 | AI-DLC 的 phase（ideation／inception／construction／operation） | repo → GH（建立時） |
+| Iteration 欄位 | `bolt-plan.md` 的 Bolt 序列 | repo → GH |
+| 卡片所在欄位 | — | **GH → repo** |
+
+### 1.2 user story → Issue
+
+`stories.md` 的結構是 `## US-n <標題>`，其下 `### 驗收標準` 為 Given/When/Then 區塊。
+
+| Issue 欄位 | 來源 | 方向 |
+|---|---|---|
+| 標題 | `US-n <標題>` | repo → GH |
+| 內文的受管區塊 | story 敘述 + 驗收標準 + Definition of Done | repo → GH |
+| 內文的受管區塊**之外** | 人手寫 | **不同步、永不觸碰** |
+| labels `aidlc` / `intent:<slug>` / `story` | 固定 | repo → GH（建立時） |
+| 其他 labels | 人／`issue-triage` | **GH → repo** |
+| state（open/closed） | — | **GH → repo** |
+| assignee | — | **GH → repo** |
+| comments | — | 不同步（只在 GitHub） |
+
+### 1.3 unit of work → Issue 的子任務
+
+`unit-of-work.md` 的每個單元渲染成受管區塊內的 task list：
+
+```markdown
+- [ ] U-1 後端回應加入 last_activity_at 欄位
+- [x] U-2 前端表格新增欄位與空態
+```
+
+勾選狀態是 **GH → repo**（人在 issue 上勾）；項目本身的增刪是 **repo → GH**。
+
+> 為什麼不用 GitHub 的 sub-issue：sub-issue 會在 issue 列表產生大量條目，與 story 平級競爭注意力，且 200+ 筆的 issue 池已經夠吵。task list 在 story issue 內部，層級關係自然。
+
+---
+
+## 2. 受管區塊格式
+
+Issue 內文的實際形狀：
+
+```markdown
+<!-- aidlc:managed intent=last-login-column story=US-1 hash=a1b2c3d4 -->
+
+## 需求
+
+作為 Security_Reviewer，我需要看到每個帳號的最後活動時間，以便判斷帳號是否仍在使用。
+
+## 驗收標準
+
+**AC-1.1**
+- **Given** 一個帳號目前無活動紀錄
+- **When** 該帳號以有效憑證發出任一需認證的請求
+- **Then** 該帳號的最後活動時間被記錄為該請求發生的時刻
+
+## 實作單元
+
+- [ ] U-1 後端回應加入 last_activity_at 欄位
+- [ ] U-2 前端表格新增欄位與空態
+
+---
+> 🤖 本區塊由 AI-DLC 自動同步自 `aidlc/spaces/default/intents/260802-last-login-column/inception/user-stories/stories.md`。
+> **在此區塊內的修改會被下次同步覆蓋**；要改需求請走 AI-DLC 流程。
+> 區塊之外的內容不會被觸碰，歡迎在下方補充討論與脈絡。
+
+<!-- /aidlc:managed -->
+
+（以下由人自由編寫，同步永不觸碰）
+```
+
+`hash` 是受管區塊內容的 SHA-256 前 8 碼，用於防迴圈（見第 4 節）。
+
+---
+
+## 3. 同步狀態檔
+
+`<record>/.aidlc-sync-state.json`，**進版控**（不是 gitignored 的 per-clone 檔——跨 runner 比對需要它）：
+
+```json
+{
+  "version": 1,
+  "intent": "last-login-column",
+  "project": { "number": 3, "node_id": "PVT_xxx", "last_synced": "2026-08-16T05:00:00Z" },
+  "stories": {
+    "US-1": {
+      "issue": 502,
+      "content_hash": "a1b2c3d4",
+      "last_pushed": "2026-08-16T05:00:00Z",
+      "last_pulled_state": { "state": "open", "assignees": ["danniel"], "labels": ["aidlc", "story"] }
+    }
+  }
+}
+```
+
+- `content_hash`：上次推送的受管區塊雜湊。**相同就不推**。
+- `last_pulled_state`：上次拉回的狀態快照。與現況相同就不開 PR。
+
+---
+
+## 4. 防迴圈（三道，缺一不可）
+
+1. **內容雜湊**：推送前算受管區塊的 SHA-256，與 `content_hash` 相同就跳過。這擋掉「內容沒變卻反覆寫入」。
+2. **commit 標記**：所有同步產生的 commit 訊息前綴 `[aidlc-sync]`。正向同步 workflow 的觸發條件排除這類 commit：
+   ```yaml
+   if: "!contains(github.event.head_commit.message, '[aidlc-sync]')"
+   ```
+3. **狀態欄位單向**：狀態只 GH → repo。repo 除了建立 issue 的初始值之外，**不寫**任何狀態欄位。單向的資料流不可能來回震盪。
+
+> 三道防線針對不同的迴圈路徑：雜湊擋內容、commit 標記擋 workflow 觸發、單向性擋語意層的來回。只做其中一道都會留下活路。
+
+---
+
+## 5. 四個階段的 workflow 規格
+
+### 階段 1：`aidlc-sync-push`（repo → Issues）
+
+```yaml
+on:
+  push:
+    branches: [ut]
+    paths:
+      - "aidlc/spaces/*/intents/*/inception/user-stories/stories.md"
+      - "aidlc/spaces/*/intents/*/inception/units-generation/unit-of-work.md"
+  workflow_dispatch:
+permissions:
+  contents: write   # 寫回 .aidlc-sync-state.json
+  issues: write     # 建立與更新 issue
+```
+
+步驟：解析 `stories.md` 的 `## US-n` → 對每個 story 算受管區塊與雜湊 → 比對 `sync-state` → 不存在則建立 issue、雜湊不同則**只替換受管區塊**（保留區塊外的人寫內容）→ 更新 `sync-state` 並以 `[aidlc-sync]` commit。
+
+**冪等性驗收**：連跑兩次，第二次的建立數與更新數皆為 0。
+
+### 階段 2：`aidlc-sync-pull`（Issues → repo）
+
+```yaml
+on:
+  schedule: [{ cron: "0 */6 * * *" }]   # 每 6 小時
+  workflow_dispatch:
+permissions:
+  contents: write
+  issues: read
+  pull-requests: write   # 反向同步一律開 PR
+```
+
+步驟：讀 `sync-state` 的 issue 清單 → 抓現況（state／assignees／labels）→ 與 `last_pulled_state` 比對，無差異就結束 → 有差異則更新 `<record>/aidlc-state.md` 的狀態欄與 `sync-state` → **開 PR**（不直接推 `ut`）。
+
+PR 標題：`整合(sync): 從 GitHub 拉回 <intent> 的狀態變更`。
+
+**為什麼一律開 PR**：反向同步是唯一可能繞過 approval gate 的路徑，PR 化讓它必須經過人眼。
+
+### 階段 3：`aidlc-sync-project`（Projects v2）
+
+需 `GH_PROJECTS_TOKEN`。Projects v2 只有 GraphQL API，與 Issues 的 REST 不同，這是它排在第三的原因。雙向：欄位定義與卡片建立為 repo → GH；卡片所在欄位為 GH → repo（併入階段 2 的 PR）。
+
+### 階段 4：`aidlc-sync-wiki`（單向鏡像）
+
+```yaml
+on:
+  push:
+    branches: [ut]
+    paths:
+      - "aidlc/spaces/*/intents/*/inception/decisions/**"
+      - "aidlc/spaces/*/intents/*/inception/user-stories/stories.md"
+      - "aidlc/spaces/*/intents/*/inception/requirements-analysis/**"
+      - "aidlc/spaces/*/intents/*/inception/application-design/**"
+      - "README.md"
+      - "DEPLOY.md"
+      - "LOCAL-DEV.md"
+      - "TESTING.md"
+```
+
+clone `<repo>.wiki.git` → 渲染（頁首加來源警語與原始路徑連結）→ commit → push。**不回寫**。
+
+---
+
+## 6. 失敗處理
+
+| 失敗 | 處置 |
+|---|---|
+| GitHub API 429／5xx | 指數退避重試 3 次；仍失敗則**保持 sync-state 不變**並讓 workflow 紅燈——寧可下次重來，不要留下 state 與現實不符 |
+| issue 被人手動刪除 | 從 sync-state 移除該筆並重新建立；在 PR 說明中記載 |
+| 受管標記被人刪掉 | **不自動修復**、不覆寫整個內文。開一則帶 `sync-conflict` 標籤的 issue 請人決定——自動重建會吃掉人寫的內容 |
+| Wiki push 衝突 | 以 repo 為準強制覆蓋（Wiki 是單向鏡像），並在 workflow log 記載被覆蓋的 commit |
+
+---
+
+## 7. 開放問題（實作前要有答案）
+
+1. **一個 intent 的 stories 改名或刪除時**，對應的 issue 怎麼處理？關閉並加 `wontfix`？還是留著？（傾向：關閉並在受管區塊註記「此 story 已從需求移除」，不刪 issue——issue 編號是外部引用點。）
+2. **`daily-digest` 每天產生 issue** 已使 issue 列表達 200+ 筆。是否該讓 digest 改用 discussion 或直接關閉舊的？這會影響同步進來的 issue 的可見度。
+3. **多個 in-flight intent 同時同步**時，Project 是每個 intent 一個（可能很多）還是全部共用一個？目前設計是前者，需確認實際使用時的數量是否可接受。
+4. **反向同步的 PR 由誰 review**？若無人 review 會堆積，若自動合併則失去它存在的意義。


### PR DESCRIPTION
設計先行的一輪：**只有 ADR 與實作藍圖，沒有實作**。實作分四階段，每階段可獨立驗收與回退。

## 四個定案

| 決定 | 內容 |
|---|---|
| **分層映射** | intent → Project、user story → Issue、unit of work → issue 內的 task list、Bolt → Project 的 iteration |
| **真實來源逐欄位切分** | **狀態**（open/closed、看板欄位、assignee、labels）以 **GitHub** 為準；**內容**（story 敘述、AC、unit 定義）以 **repo** 為準 |
| **Wiki 單向鏡像** | 只放已核可 artifacts 與根層文件，不同步中間過程文件 |
| **反向同步一律開 PR** | 不直接推 `ut` |

**逐欄位切分是核心決定。** 人在看板上拖卡片本來就是正式操作，要求他改 repo 才算數等於否定看板的意義；但驗收標準經過 AI-DLC 的 approval gate，若任何人在 issue 上改 AC 就能覆寫回 repo，那個 gate 形同虛設。

issue 內文用 `<!-- aidlc:managed -->` 標記分區 —— 區塊內由 repo 覆寫，**區塊外的人寫內容永不觸碰**。這讓「內容 repo 贏」不至於吃掉協作者補充的脈絡。

## 兩個查證出來、會改變設計的事實

**1. gh-aw 的 `safe-outputs` 做不到你要的「修改」**

實測支援的只有 `create-issue` / `close-issue` / `add-comment` / `add-labels` / `push-to-pull-request-branch`。**沒有更新 issue 內文、沒有 Projects、沒有 Wiki。**

所以必須提權直接呼叫 `gh` CLI / GraphQL。這是對既有安全模型的**實質放寬**，ADR 記為最大風險項。補償控制：同步 workflow 與其他 agentic workflow 分離、不共用 token，且反向同步 PR 化。

**2. Wiki 的 git repo 根本不存在**

`has_wiki=true` 但 `<repo>.wiki.git` 從未初始化 —— GitHub 要先手動建第一頁才會生成。已列為前置條件 P1。

## 防迴圈三道，缺一都留活路

1. 受管區塊**內容雜湊**比對 —— 擋「內容沒變卻反覆寫入」
2. commit 訊息 `[aidlc-sync]` 標記**排除觸發** —— 擋 workflow 互相引爆
3. **狀態欄位單向流動** —— 單向的資料流不可能來回震盪

## 否決的替代方案（都記了理由）

- **repo 永遠贏**：等於叫人別在 GitHub 上操作，拖卡片會被下次同步彈回原位，比沒有同步更糟
- **GitHub 永遠贏**：直接摧毀 approval gate
- **衝突開 issue 請人決定**：狀態的雙邊修改是**常態**而非例外，衝突 issue 會重演 `daily-digest` 淹沒 issue 列表的情況

## 藍圖內容

五個實作前置條件（含 Projects v2 需要獨立 token —— `GITHUB_TOKEN` 不涵蓋它）、逐欄位映射表、受管區塊的實際 markdown 形狀、`sync-state` schema、四個 workflow 的觸發與權限規格、失敗處理表、四個待答的開放問題。

## 需要注意的既有干擾

`issue-triage` 會對新 issue 分類貼標籤，而同步會建立大量帶 `aidlc` 標籤的 issue —— 前置條件 P5 要求先讓它排除這類 issue，否則兩個 workflow 會互相改標籤來回震盪。

## 追加：與 AI-DLC 主流程零耦合（硬約束）

原本的設計實際上就沒有碰 `.claude/`，但那是**隱含性質**而非明文約束 —— 隱含的約束等於沒有約束，下一個實作的人不會知道不能碰。

順帶查證了 AI-DLC 的 plugin 機制究竟提供什麼隔離，結論會影響設計選擇：

> **plugin 不提供升級隔離。** `harness.json` 的 `plugins` 欄位只是啟用 allowlist；沒有任何工具會從 `plugins/<name>/` 安裝東西；stage 檔仍然**只能**放在 `.claude/aidlc-common/stages/`（`aidlc-graph.ts` 的 `stagesDir()` 只掃這一個目錄，`AIDLC_STAGES_DIR` 是測試 seam 不是安裝點）。

本 repo 的 `tcms-test-cases` 就是實例 —— 它**是** plugin stage，仍然得靠 repo contract 與 `README-cloud360.md` 登記才不會在升級時無聲消失。

所以「做成 plugin」不足以達成升級韌性。有效的做法是**完全不進 `.claude/`**：

| 元件 | 位置 | 升級影響 |
|---|---|---|
| 同步 workflow | `.github/workflows/aidlc-sync-*.md` | 無 |
| 同步腳本 | `scripts/aidlc_sync_*.py` | 無 |
| 同步狀態 | `<record>/.aidlc-sync-state.json` | 無 |
| 規則說明 | `memory/project.md` | 無 |

**觸發用 git push，不是 stage 或 hook。** AI-DLC 產出 artifact 並 commit 後，`on: push` 的 paths 過濾自然觸發；AI-DLC 對同步一無所知。

### 可執行的升級韌性驗收

不是宣稱，是檢查：

```bash
# 暫時移走 .claude/，同步腳本仍須能獨立執行
mv .claude /tmp/claude-backup
python3 scripts/aidlc_sync_push.py --dry-run    # 應正常執行
mv /tmp/claude-backup .claude
```

這把「不得 import `.claude/` 下任何東西」變成可驗證的事實而不是承諾。

### 代價（誠實記在 Consequences）

同步時機是 **commit 之後**而非 stage 完成的當下，且看不到 stage 內部的中間狀態。artifact 本來就要進版控才算數，所以這個延遲沒有實際損失 —— 但若日後證明粒度不夠，才重新評估是否值得為此承擔升級維護成本。

Alternatives 新增 **E（做成 plugin stage）**，記錄兩個否決理由：不提供升級隔離；以及同步根本不需要流程內的資訊 —— 它要的是 artifact 的最終內容，`on: push` 拿得到一模一樣的東西。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
