### PR TITLE
修正安全稽核問題

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          CLOUD360_BOOTSTRAP_ADMIN_PASSWORD: ${{ secrets.CLOUD360_BOOTSTRAP_ADMIN_PASSWORD }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           N8N_WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           N8N_USER: ${{ secrets.N8N_USER }}
@@ -187,6 +188,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          CLOUD360_BOOTSTRAP_ADMIN_PASSWORD: ${{ secrets.CLOUD360_BOOTSTRAP_ADMIN_PASSWORD }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           N8N_WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           N8N_USER: ${{ secrets.N8N_USER }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -288,12 +288,10 @@ psql "$DATABASE_URL" -c "SELECT role, story_id, can_view, can_edit, updated_by F
 執行 `schema_rbac.sql` 後：
 
 1. **`role_permissions`**：寫入設計預設矩陣（約 **308** 列，11 角色 × 各 Story）。  
-2. **`users`**：若不存在則建立  
-   - 帳號：`admin`  
-   - 密碼：`admin123`（**上線後請立刻改密碼**）  
-   - 角色：`Platform_Admin`（可進「使用者角色」「角色細項權限」）
+2. **`users`**：只建表，不建立固定密碼管理員。
 
-後端若在**空庫**啟動，`init_db()` 也會：建表、必要時 seed `role_permissions`、確保有 `admin`。  
+後端若在**空庫**啟動，`init_db()` 也會：建表、必要時 seed `role_permissions`。
+Local/test 環境仍會 seed demo 帳號；staging/production 不會建立固定密碼使用者。全新部署若需要 bootstrap admin，請在第一次啟動前設定 `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD` 為強隨機臨時密碼，登入後立刻輪替或清除該 secret。
 **新環境仍建議先跑 `schema_rbac.sql`**，行為與文件一致、不依賴啟動順序。
 
 #### 2.4 重要：若沒跑 seed，角色細項會是「全空」
@@ -301,7 +299,7 @@ psql "$DATABASE_URL" -c "SELECT role, story_id, can_view, can_edit, updated_by F
 | 情況 | 結果 |
 |---|---|
 | 只建空表、**沒有**插入 `role_permissions` | 矩陣**全空**（所有角色對所有功能都無檢視／編輯／審核）→ Sidebar 幾乎看不到功能、API 易 403 |
-| 有跑 `schema_rbac.sql`（或後端空表自動 seed） | 有設計預設權限，可用 `admin` 登入再在 Admin UI 調整 |
+| 有跑 `schema_rbac.sql`（或後端空表自動 seed） | 有設計預設權限；需搭配既有管理員或 `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD` 建立的 bootstrap admin 調整 |
 
 因此：**新環境請務必執行 `schema_rbac.sql`（或確認啟動後 `role_permissions` 列數約 308）**，不要只建表不塞預設。
 
@@ -387,9 +385,9 @@ docker compose -f deploy/docker-compose.deploy.yml --env-file deploy/.env exec b
 1. 準備 PostgreSQL，設定 `DATABASE_URL`  
 2. 執行 `psql "$DATABASE_URL" -f schema_rbac.sql`  
 3. 準備 LLM：OpenRouter 金鑰 ＋ **Claude Code CLI**（Docker build 或本機安裝）  
-4. 設定後端 `.env`／`deploy/.env`（含 `CORS_ORIGINS`、`JWT_SECRET`、LLM／token 變數）並啟動 API  
+4. 設定後端 `.env`／`deploy/.env`（含 `CORS_ORIGINS`、`JWT_SECRET`、LLM／token 變數；全新 staging 可選 `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD`）並啟動 API
 5. 設定前端 `VITE_API_BASE_URL` 後 build／部署  
-6. 用 `admin` / `admin123` 登入 → **立刻改密碼** → 調整角色權限  
+6. 用既有管理員或 bootstrap admin 登入 → **立刻輪替臨時密碼／清除 bootstrap secret** → 調整角色權限
 7. 依第 3.4 節做 A1／A3／優化煙測  
 
 ---
@@ -441,10 +439,10 @@ psql "$DATABASE_URL" -f schema_rbac.sql
 ```
 
 Creates: `users`, `user_diagrams`, `diagram_shares`, `user_diagram_chats`, **`architecture_reviews` (A3)**, **`wa_lenses` (editable offline Lens)**, `role_permissions`, plus `last_opened_diagram_id`.  
-Seeds ~**308** `role_permissions` rows and default user **`admin` / `admin123`** (`Platform_Admin`) if missing.
+Seeds ~**308** `role_permissions` rows. It does **not** create a fixed-password admin user.
 
 **A3** `architecture_reviews` stores review scores/findings/suggestions. **`wa_lenses`** stores the active Custom Lens JSON editable by users with **A3.review** (default: Security_Reviewer VER; reviews resolve DB-first, then file fallback). Existing DBs: re-run `schema_rbac.sql` (`IF NOT EXISTS`) or rely on backend `_ensure_a3_schema()` on startup.
 
 **If you create empty tables without seeding `role_permissions`, the matrix is entirely empty** — no view/edit/review for any role, Sidebar stays empty, APIs return 403. Always run `schema_rbac.sql` (or confirm ~308 rows after backend empty-DB seed).
 
-Re-running **wipes and re-seeds** `role_permissions` (backup first if customized). Does not overwrite an existing admin password. Change `admin123` immediately after first login.
+Re-running **wipes and re-seeds** `role_permissions` (backup first if customized). Bootstrap admin creation is handled by backend startup via `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD`, not by this SQL script.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -291,7 +291,7 @@ psql "$DATABASE_URL" -c "SELECT role, story_id, can_view, can_edit, updated_by F
 2. **`users`**：只建表，不建立固定密碼管理員。
 
 後端若在**空庫**啟動，`init_db()` 也會：建表、必要時 seed `role_permissions`。
-Local/test 環境仍會 seed demo 帳號；staging/production 不會建立固定密碼使用者。全新部署若需要 bootstrap admin，請在第一次啟動前設定 `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD` 為強隨機臨時密碼，登入後立刻輪替或清除該 secret。
+Local 環境仍會 seed demo persona 帳號；test/ci 只會建立 `admin/admin123` 供自動化測試使用；staging/production 不會建立固定密碼使用者。全新部署若需要 bootstrap admin，請在第一次啟動前設定 `CLOUD360_BOOTSTRAP_ADMIN_PASSWORD` 為強隨機臨時密碼，登入後立刻輪替或清除該 secret。
 **新環境仍建議先跑 `schema_rbac.sql`**，行為與文件一致、不依賴啟動順序。
 
 #### 2.4 重要：若沒跑 seed，角色細項會是「全空」

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,9 +68,17 @@ APP_ENV=local
 # 本機 PostgreSQL。用 docker 起一顆的指令見 LOCAL-DEV.md §2。
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cloud360
 
-# JWT 簽章金鑰。未設定時 auth.py 會退回這個公開在 repo 裡的預設值，
-# 本機無妨，但別把同一個值帶去任何對外環境。
+# JWT 簽章金鑰。APP_ENV=local/test/ci 未設定時會使用開發用 fallback；
+# staging/production 缺 JWT_SECRET 會直接拒絕啟動。
 JWT_SECRET=cloud360_secret_key_change_me_in_production
+
+# 固定 demo 使用者只允許 local/test/ci，或非 local 明確 opt-in。
+# 不要在對外環境開啟，除非是一次性、隔離的 demo stack。
+# ALLOW_INSECURE_DEFAULT_USERS=false
+
+# 全新 staging/production 若需要建立第一個 Platform_Admin，可設定強隨機臨時密碼；
+# 登入後立即輪替帳密並清除此值。local/test 會自動使用 admin123。
+# CLOUD360_BOOTSTRAP_ADMIN_PASSWORD=
 
 # 允許的前端來源（CORS，逗號分隔）。這裡放的是本機 vite dev server 的位址；
 # 部署環境的來源由 deploy/.env 的 PUBLIC_URL 決定，不要混寫在這裡。

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -72,9 +72,13 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cloud360
 # staging/production 缺 JWT_SECRET 會直接拒絕啟動。
 JWT_SECRET=cloud360_secret_key_change_me_in_production
 
-# 固定 demo 使用者只允許 local/test/ci，或非 local 明確 opt-in。
+# 固定 bootstrap admin 只允許 local/test/ci，或非 local 明確 opt-in。
 # 不要在對外環境開啟，除非是一次性、隔離的 demo stack。
 # ALLOW_INSECURE_DEFAULT_USERS=false
+
+# 11 位 persona demo 帳號只在 local 自動建立；test/ci 僅建立 admin，避免
+# UI regression 的資料前提漂移。非 local 若要 demo personas 需另外明確 opt-in。
+# ALLOW_INSECURE_DEFAULT_PERSONAS=false
 
 # 全新 staging/production 若需要建立第一個 Platform_Admin，可設定強隨機臨時密碼；
 # 登入後立即輪替帳密並清除此值。local/test 會自動使用 admin123。

--- a/backend/database.py
+++ b/backend/database.py
@@ -41,6 +41,13 @@ def _allow_insecure_default_users() -> bool:
     return _truthy_env("ALLOW_INSECURE_DEFAULT_USERS")
 
 
+def _allow_insecure_default_personas() -> bool:
+    """Seed the multi-persona demo catalog only where it is intentionally useful."""
+    if _current_app_env() == "local":
+        return True
+    return _truthy_env("ALLOW_INSECURE_DEFAULT_PERSONAS")
+
+
 def _bootstrap_admin_password() -> str | None:
     password = os.environ.get("CLOUD360_BOOTSTRAP_ADMIN_PASSWORD", "").strip()
     if password:
@@ -74,7 +81,7 @@ def init_db():
     try:
         # 檢查是否已存在使用者
         user_count = db.query(User).count()
-        if user_count == 0 and _allow_insecure_default_users():
+        if user_count == 0 and _allow_insecure_default_personas():
             logger.info("資料庫為空，開始從 personas.md 初始化 11 位預設使用者...")
 
             default_personas = [
@@ -106,7 +113,7 @@ def init_db():
             logger.info("預設使用者初始化完成！")
         elif user_count == 0:
             logger.warning(
-                "資料庫為空，但 APP_ENV=%s 未允許固定密碼 demo seed；略過預設使用者建立。",
+                "資料庫為空，但 APP_ENV=%s 未允許 demo persona seed；略過 persona 建立。",
                 _current_app_env(),
             )
         else:

--- a/backend/database.py
+++ b/backend/database.py
@@ -23,6 +23,32 @@ DATABASE_URL = os.environ.get(
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+LOCAL_APP_ENVS = {"local", "test", "ci"}
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _current_app_env() -> str:
+    return os.environ.get("APP_ENV", app_env).strip().lower()
+
+
+def _allow_insecure_default_users() -> bool:
+    """Fixed demo credentials are only acceptable in local/test, or by opt-in."""
+    if _current_app_env() in LOCAL_APP_ENVS:
+        return True
+    return _truthy_env("ALLOW_INSECURE_DEFAULT_USERS")
+
+
+def _bootstrap_admin_password() -> str | None:
+    password = os.environ.get("CLOUD360_BOOTSTRAP_ADMIN_PASSWORD", "").strip()
+    if password:
+        return password
+    if _allow_insecure_default_users():
+        return "admin123"
+    return None
+
 def hash_password(password: str) -> str:
     pwd_bytes = password.encode('utf-8')
     salt = bcrypt.gensalt()
@@ -48,7 +74,7 @@ def init_db():
     try:
         # 檢查是否已存在使用者
         user_count = db.query(User).count()
-        if user_count == 0:
+        if user_count == 0 and _allow_insecure_default_users():
             logger.info("資料庫為空，開始從 personas.md 初始化 11 位預設使用者...")
 
             default_personas = [
@@ -78,24 +104,36 @@ def init_db():
 
             db.commit()
             logger.info("預設使用者初始化完成！")
+        elif user_count == 0:
+            logger.warning(
+                "資料庫為空，但 APP_ENV=%s 未允許固定密碼 demo seed；略過預設使用者建立。",
+                _current_app_env(),
+            )
         else:
             logger.info(f"資料庫已存在 {user_count} 位使用者，跳過初始化。")
 
         # 確保預設 admin 帳號存在（與 schema_rbac.sql 對齊）
         admin = db.query(User).filter(User.username == "admin").first()
+        bootstrap_admin_password = _bootstrap_admin_password()
         if admin is None:
-            db.add(
-                User(
-                    username="admin",
-                    password_hash=hash_password("admin123"),
-                    role="Platform_Admin",
-                    is_active=True,
-                    authorization_status="approved",
+            if bootstrap_admin_password:
+                db.add(
+                    User(
+                        username="admin",
+                        password_hash=hash_password(bootstrap_admin_password),
+                        role="Platform_Admin",
+                        is_active=True,
+                        authorization_status="approved",
+                    )
                 )
-            )
-            db.commit()
-            logger.info("已建立預設帳號 admin / Platform_Admin")
-        elif getattr(admin, "authorization_status", None) != "approved":
+                db.commit()
+                logger.info("已建立 bootstrap admin / Platform_Admin")
+            else:
+                logger.warning(
+                    "未設定 CLOUD360_BOOTSTRAP_ADMIN_PASSWORD；APP_ENV=%s 不建立固定密碼 admin。",
+                    _current_app_env(),
+                )
+        elif bootstrap_admin_password and getattr(admin, "authorization_status", None) != "approved":
             admin.authorization_status = "approved"
             if not admin.role:
                 admin.role = "Platform_Admin"

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -11,7 +11,24 @@ from models import User
 from services.activity import record_activity
 
 # Security Configurations
-SECRET_KEY = os.environ.get("JWT_SECRET", "cloud360_secret_key_change_me_in_production")
+INSECURE_DEV_SECRET = "cloud360_secret_key_change_me_in_production"
+LOCAL_APP_ENVS = {"local", "test", "ci"}
+
+
+def _env_allows_insecure_defaults() -> bool:
+    return os.environ.get("APP_ENV", "local").strip().lower() in LOCAL_APP_ENVS
+
+
+def _resolve_secret_key() -> str:
+    secret = os.environ.get("JWT_SECRET", "").strip()
+    if secret:
+        return secret
+    if _env_allows_insecure_defaults():
+        return INSECURE_DEV_SECRET
+    raise RuntimeError("JWT_SECRET is required outside local/test environments")
+
+
+SECRET_KEY = _resolve_secret_key()
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 8  # 預設 8 小時
 
@@ -30,18 +47,15 @@ def get_password_hash(password: str) -> str:
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
-def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security_bearer),
-    db: Session = Depends(get_db)
-) -> User:
-    token = credentials.credentials
+
+def get_user_from_token(token: str, db: Session, *, record: bool = True) -> User:
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="身分驗證失敗，憑證無效或已過期",
@@ -54,7 +68,7 @@ def get_current_user(
             raise credentials_exception
     except jwt.PyJWTError:
         raise credentials_exception
-        
+
     user = db.query(User).filter(User.username == username).first()
     if user is None:
         raise credentials_exception
@@ -63,11 +77,18 @@ def get_current_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="該帳號已被停用"
         )
-    # PU-1：任何以有效憑證發出的請求都更新該帳號的最後活動時間（節流見 C-1）。
-    # 放在這裡而非各 router，是因為這是所有認證請求的唯一必經點。
-    # record_activity 自行管理交易並吞掉自身的失敗——記錄失敗不得讓使用者請求失敗。
-    record_activity(db, user)
+    if record:
+        # PU-1：任何以有效憑證發出的請求都更新該帳號的最後活動時間（節流見 C-1）。
+        # record_activity 自行管理交易並吞掉自身的失敗——記錄失敗不得讓使用者請求失敗。
+        record_activity(db, user)
     return user
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security_bearer),
+    db: Session = Depends(get_db)
+) -> User:
+    return get_user_from_token(credentials.credentials, db)
 
 class RoleChecker:
     def __init__(self, allowed_roles: List[str]):

--- a/backend/services/collab_router.py
+++ b/backend/services/collab_router.py
@@ -19,9 +19,9 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from database import get_db
+from database import SessionLocal, get_db
 from models import User, UserDiagram, UserDiagramChat, diagram_shares
-from services.auth import get_current_user
+from services.auth import get_current_user, get_user_from_token
 from services.rbac import require_arch_action, user_can_arch
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,10 @@ router = APIRouter()
 
 # 限制持久化輪數，避免 messages_json 過大
 MAX_CHAT_MESSAGES = 100
+MAX_DIAGRAM_XML_CHARS = 2 * 1024 * 1024
+MAX_DIAGRAM_TITLE_CHARS = 200
+MAX_CHAT_CONTENT_CHARS = 8000
+MAX_WS_MESSAGE_CHARS = MAX_DIAGRAM_XML_CHARS
 
 DEFAULT_WELCOME = (
     "嗨！我是您的 AI 雲端架構助理 👋\n"
@@ -218,17 +222,76 @@ def _get_or_create_chat(
     return chat
 
 
+def _looks_like_diagram_xml(xml: str) -> bool:
+    lowered = (xml or "").lower()
+    return "<mxgraphmodel" in lowered or "<mxfile" in lowered
+
+
+def _validate_diagram_payload(xml: str) -> None:
+    if not xml or not xml.strip():
+        raise HTTPException(status_code=400, detail="xml_data 不可為空")
+    if len(xml) > MAX_DIAGRAM_XML_CHARS:
+        raise HTTPException(status_code=400, detail="架構圖檔過大（上限約 2MB）")
+    if not _looks_like_diagram_xml(xml):
+        raise HTTPException(status_code=400, detail="xml_data 不是有效的 draw.io 架構圖 XML")
+
+
+def _validate_chat_messages(messages: List[dict[str, str]]) -> None:
+    if len(messages) > MAX_CHAT_MESSAGES:
+        raise HTTPException(status_code=400, detail=f"聊天紀錄最多保留 {MAX_CHAT_MESSAGES} 則")
+    for m in messages:
+        content = str(m.get("content", ""))
+        if len(content) > MAX_CHAT_CONTENT_CHARS:
+            raise HTTPException(status_code=400, detail="單則聊天內容過長")
+
+
+def _workspace_id_to_diagram_id(workspace_id: str) -> int:
+    try:
+        return int(workspace_id)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="workspace_id 必須是 diagram id") from e
+
+
+def _authorize_ws_user(workspace_id: str, token: Optional[str], db: Session) -> User:
+    if not token:
+        raise HTTPException(status_code=401, detail="WebSocket 需要 token")
+    user = get_user_from_token(token, db, record=False)
+    diagram_id = _workspace_id_to_diagram_id(workspace_id)
+    _get_accessible_diagram(diagram_id, user, db)
+    if not _arch_can_edit(db, user):
+        raise HTTPException(status_code=403, detail="WebSocket 共編需要架構圖編輯權限")
+    return user
+
+
 @router.websocket("/ws/{workspace_id}")
 async def websocket_endpoint(websocket: WebSocket, workspace_id: str):
+    db = SessionLocal()
+    try:
+        _authorize_ws_user(workspace_id, websocket.query_params.get("token"), db)
+    except HTTPException as e:
+        code = 1008 if e.status_code in (401, 403) else 1003
+        await websocket.close(code=code, reason=str(e.detail)[:120])
+        return
+    finally:
+        db.close()
+
     await manager.connect(websocket, workspace_id)
     try:
         while True:
             data = await websocket.receive_text()
+            if len(data) > MAX_WS_MESSAGE_CHARS:
+                await websocket.close(code=1009, reason="架構圖訊息過大")
+                break
+            if not _looks_like_diagram_xml(data):
+                await websocket.close(code=1003, reason="WebSocket 只接受 draw.io XML")
+                break
             try:
                 await manager.broadcast(data, workspace_id, exclude=websocket)
             except Exception as e:
                 logger.error("Error processing message: %s", e)
     except WebSocketDisconnect:
+        pass
+    finally:
         manager.disconnect(websocket, workspace_id)
 
 
@@ -243,8 +306,8 @@ def get_users(
 
 
 class SaveDiagramRequest(BaseModel):
-    xml_data: str
-    title: str = "未命名架構圖"
+    xml_data: str = Field(..., min_length=1, max_length=MAX_DIAGRAM_XML_CHARS)
+    title: str = Field("未命名架構圖", min_length=1, max_length=MAX_DIAGRAM_TITLE_CHARS)
 
 
 class ShareDiagramRequest(BaseModel):
@@ -252,7 +315,7 @@ class ShareDiagramRequest(BaseModel):
 
 
 class SaveChatRequest(BaseModel):
-    messages: List[dict[str, str]] = Field(default_factory=list)
+    messages: List[dict[str, str]] = Field(default_factory=list, max_length=MAX_CHAT_MESSAGES)
 
 
 class LastOpenedRequest(BaseModel):
@@ -387,6 +450,7 @@ def save_diagram_chat(
     db: Session = Depends(get_db),
 ):
     _get_accessible_diagram(diagram_id, current_user, db)
+    _validate_chat_messages(request.messages)
     chat = _get_or_create_chat(current_user.id, diagram_id, db)
     chat.messages_json = _serialize_messages(request.messages)
     current_user.last_opened_diagram_id = diagram_id
@@ -449,6 +513,7 @@ def create_diagram(
     current_user: User = Depends(require_arch_action("edit")),
     db: Session = Depends(get_db),
 ):
+    _validate_diagram_payload(request.xml_data)
     diagram = UserDiagram(
         user_id=current_user.id, title=request.title, xml_data=request.xml_data
     )
@@ -472,6 +537,7 @@ def update_diagram(
     db: Session = Depends(get_db),
 ):
     diagram = _get_accessible_diagram(diagram_id, current_user, db)
+    _validate_diagram_payload(request.xml_data)
     # 僅擁有者可改 XML（被分享者若有 edit 仍可協作寫入）
     diagram.xml_data = request.xml_data
     diagram.title = request.title

--- a/backend/services/user_router.py
+++ b/backend/services/user_router.py
@@ -389,7 +389,8 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
             detail="您的帳號已被停用，請聯絡平台管理員",
         )
 
-    record_activity(db, user)
+    if record_activity(db, user):
+        db.refresh(user)
     access_token = create_access_token(data={"sub": user.username})
     return {
         "access_token": access_token,
@@ -501,6 +502,8 @@ def list_users(
     頁次**合法但超出範圍**時不是錯誤：offset 超過總數，查詢自然回空清單，
     `page` 照樣回顯請求值（FR-6.4，不夾到最後一頁）。
     """
+    if record_activity(db, admin_user):
+        db.refresh(admin_user)
     now = datetime.now(timezone.utc)
     # total 為獨立的計數查詢，**不得**由 len(items) 導出——後者只在多頁時才錯，
     # 而目前的資料量下多頁情境不會自然出現（BR-P2）。

--- a/backend/services/user_router.py
+++ b/backend/services/user_router.py
@@ -22,7 +22,7 @@ from services.auth import (
     create_access_token,
     get_current_user,
 )
-from services.activity import as_aware_utc, is_overdue
+from services.activity import as_aware_utc, is_overdue, record_activity
 from services.rbac import (
     CANONICAL_ROLES,
     STORY_IDS,
@@ -389,6 +389,7 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
             detail="您的帳號已被停用，請聯絡平台管理員",
         )
 
+    record_activity(db, user)
     access_token = create_access_token(data={"sub": user.username})
     return {
         "access_token": access_token,

--- a/backend/services/user_router.py
+++ b/backend/services/user_router.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 import logging
 import re
@@ -110,6 +110,8 @@ class LoginResponse(BaseModel):
 
 
 class UserSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     username: str
     role: Optional[str] = None
@@ -121,9 +123,6 @@ class UserSchema(BaseModel):
     # 構造當下就是 ValidationError。
     last_activity_at: Optional[datetime]
     is_overdue: bool
-
-    class Config:
-        orm_mode = True
 
 
 # 每頁筆數（AD-10）：預設 20、上限 100。上限讓單次回應有界（NFR-8）。
@@ -193,6 +192,8 @@ class ResetDefaultsResponse(BaseModel):
 
 
 class AuthorizationRequestSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     user_id: int
     username: str
@@ -202,9 +203,6 @@ class AuthorizationRequestSchema(BaseModel):
     updated_at: Optional[datetime] = None
     decided_by: Optional[str] = None
     decided_at: Optional[datetime] = None
-
-    class Config:
-        orm_mode = True
 
 
 def _audit_append(title: str, request_raw: str, outcome: str, approver: str) -> None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -8,9 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 from hypothesis import given, settings, strategies as st
+from starlette.testclient import TestClient
 
-from tests.helpers import close_session, make_session, make_user
-
+from database import get_db
+from main import app
 from services import auth
 from services.auth import (
     ALGORITHM,
@@ -20,6 +21,7 @@ from services.auth import (
     get_password_hash,
     verify_password,
 )
+from tests.helpers import close_session, make_session, make_user
 
 
 class TestPasswordHashing(unittest.TestCase):
@@ -75,6 +77,35 @@ class TestSecretConfiguration(unittest.TestCase):
             clear=True,
         ):
             self.assertEqual(auth._resolve_secret_key(), "configured-secret")
+
+
+class TestLoginActivity(unittest.TestCase):
+    def setUp(self):
+        self.db = make_session()
+        self.user = make_user(
+            self.db,
+            username="admin",
+            role="Platform_Admin",
+            password_hash=get_password_hash("admin123"),
+        )
+        app.dependency_overrides[get_db] = lambda: self.db
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        close_session(self.db)
+
+    def test_successful_login_records_last_activity(self):
+        self.assertIsNone(self.user.last_activity_at)
+
+        res = self.client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "admin123"},
+        )
+
+        self.assertEqual(res.status_code, 200)
+        self.db.refresh(self.user)
+        self.assertIsNotNone(self.user.last_activity_at)
 
 
 class TestGetCurrentUser(unittest.TestCase):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jwt
 from hypothesis import given, settings, strategies as st
@@ -14,6 +14,7 @@ from tests.helpers import close_session, make_session, make_user
 from services import auth
 from services.auth import (
     ALGORITHM,
+    INSECURE_DEV_SECRET,
     SECRET_KEY,
     create_access_token,
     get_password_hash,
@@ -55,6 +56,25 @@ class TestAccessToken(unittest.TestCase):
         bad = token[:-4] + ("AAAA" if not token.endswith("AAAA") else "BBBB")
         with self.assertRaises(jwt.PyJWTError):
             jwt.decode(bad, SECRET_KEY, algorithms=[ALGORITHM])
+
+
+class TestSecretConfiguration(unittest.TestCase):
+    def test_local_env_allows_dev_secret(self):
+        with patch.dict(auth.os.environ, {"APP_ENV": "local"}, clear=True):
+            self.assertEqual(auth._resolve_secret_key(), INSECURE_DEV_SECRET)
+
+    def test_non_local_env_requires_jwt_secret(self):
+        with patch.dict(auth.os.environ, {"APP_ENV": "production"}, clear=True):
+            with self.assertRaises(RuntimeError):
+                auth._resolve_secret_key()
+
+    def test_non_local_env_uses_configured_secret(self):
+        with patch.dict(
+            auth.os.environ,
+            {"APP_ENV": "production", "JWT_SECRET": "configured-secret"},
+            clear=True,
+        ):
+            self.assertEqual(auth._resolve_secret_key(), "configured-secret")
 
 
 class TestGetCurrentUser(unittest.TestCase):

--- a/backend/tests/test_collab.py
+++ b/backend/tests/test_collab.py
@@ -12,17 +12,24 @@ from tests.helpers import close_session, make_diagram, make_session, make_user
 
 from services.collab_router import (
     DEFAULT_WELCOME,
+    MAX_CHAT_CONTENT_CHARS,
+    MAX_DIAGRAM_XML_CHARS,
     MAX_CHAT_MESSAGES,
     REVIEW_ONLY_WELCOME,
     VIEW_ONLY_WELCOME,
+    _authorize_ws_user,
     _get_accessible_diagram,
     _get_or_create_chat,
     _parse_messages,
     _serialize_messages,
     _user_can_access_diagram,
+    _validate_chat_messages,
+    _validate_diagram_payload,
     _visible_diagrams,
     _welcome_for_user,
+    _workspace_id_to_diagram_id,
 )
+from services.auth import create_access_token
 
 
 class TestAccessHelpers(unittest.TestCase):
@@ -140,6 +147,63 @@ class TestChatMessages(unittest.TestCase):
         raw = _serialize_messages(messages)
         back = _parse_messages(raw)
         self.assertEqual(back, [{"role": m["role"], "content": str(m["content"])} for m in messages])
+
+
+class TestPayloadValidation(unittest.TestCase):
+    def test_diagram_payload_accepts_drawio_xml(self):
+        _validate_diagram_payload("<mxGraphModel><root /></mxGraphModel>")
+
+    def test_diagram_payload_rejects_non_diagram_xml(self):
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_diagram_payload("<not-a-diagram />")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_diagram_payload_rejects_large_xml(self):
+        xml = "<mxGraphModel>" + ("x" * MAX_DIAGRAM_XML_CHARS) + "</mxGraphModel>"
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_diagram_payload(xml)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_chat_validation_rejects_large_message(self):
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_chat_messages(
+                [{"role": "user", "content": "x" * (MAX_CHAT_CONTENT_CHARS + 1)}]
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_workspace_id_must_be_diagram_id(self):
+        self.assertEqual(_workspace_id_to_diagram_id("123"), 123)
+        with self.assertRaises(HTTPException):
+            _workspace_id_to_diagram_id("abc")
+
+
+class TestWebSocketAuthorization(unittest.TestCase):
+    def setUp(self):
+        self.db = make_session()
+        self.owner = make_user(self.db, username="alex", role="Project_Architect")
+        self.viewer = make_user(self.db, username="viewer", role="FinOps_Analyst")
+        self.diagram = make_diagram(self.db, owner=self.owner)
+
+    def tearDown(self):
+        close_session(self.db)
+
+    def test_ws_authorizes_editor_for_owned_diagram(self):
+        token = create_access_token({"sub": self.owner.username})
+        user = _authorize_ws_user(str(self.diagram.id), token, self.db)
+        self.assertEqual(user.id, self.owner.id)
+
+    def test_ws_rejects_missing_token(self):
+        with self.assertRaises(HTTPException) as ctx:
+            _authorize_ws_user(str(self.diagram.id), None, self.db)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_ws_rejects_user_without_edit_permission(self):
+        self.diagram.shared_users.append(self.viewer)
+        self.db.commit()
+        token = create_access_token({"sub": self.viewer.username})
+        with self.assertRaises(HTTPException) as ctx:
+            _authorize_ws_user(str(self.diagram.id), token, self.db)
+        self.assertEqual(ctx.exception.status_code, 403)
 
 
 class TestGetOrCreateChat(unittest.TestCase):

--- a/backend/tests/test_database_security.py
+++ b/backend/tests/test_database_security.py
@@ -1,0 +1,45 @@
+"""Security tests for database bootstrap defaults."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import tests.helpers  # noqa: F401 — path / psycopg2 setup
+from database import _allow_insecure_default_users, _bootstrap_admin_password
+
+
+class DatabaseBootstrapSecurityTest(unittest.TestCase):
+    def test_local_env_allows_demo_seed(self):
+        with patch.dict("os.environ", {"APP_ENV": "local"}, clear=True):
+            self.assertTrue(_allow_insecure_default_users())
+            self.assertEqual(_bootstrap_admin_password(), "admin123")
+
+    def test_production_env_blocks_fixed_demo_seed_by_default(self):
+        with patch.dict("os.environ", {"APP_ENV": "production"}, clear=True):
+            self.assertFalse(_allow_insecure_default_users())
+            self.assertIsNone(_bootstrap_admin_password())
+
+    def test_production_env_can_use_explicit_bootstrap_password(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "APP_ENV": "production",
+                "CLOUD360_BOOTSTRAP_ADMIN_PASSWORD": "one-time-secret",
+            },
+            clear=True,
+        ):
+            self.assertFalse(_allow_insecure_default_users())
+            self.assertEqual(_bootstrap_admin_password(), "one-time-secret")
+
+    def test_non_local_demo_seed_requires_explicit_opt_in(self):
+        with patch.dict(
+            "os.environ",
+            {"APP_ENV": "staging", "ALLOW_INSECURE_DEFAULT_USERS": "true"},
+            clear=True,
+        ):
+            self.assertTrue(_allow_insecure_default_users())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_database_security.py
+++ b/backend/tests/test_database_security.py
@@ -6,18 +6,30 @@ import unittest
 from unittest.mock import patch
 
 import tests.helpers  # noqa: F401 — path / psycopg2 setup
-from database import _allow_insecure_default_users, _bootstrap_admin_password
+from database import (
+    _allow_insecure_default_personas,
+    _allow_insecure_default_users,
+    _bootstrap_admin_password,
+)
 
 
 class DatabaseBootstrapSecurityTest(unittest.TestCase):
     def test_local_env_allows_demo_seed(self):
         with patch.dict("os.environ", {"APP_ENV": "local"}, clear=True):
             self.assertTrue(_allow_insecure_default_users())
+            self.assertTrue(_allow_insecure_default_personas())
+            self.assertEqual(_bootstrap_admin_password(), "admin123")
+
+    def test_test_env_bootstraps_admin_without_demo_personas(self):
+        with patch.dict("os.environ", {"APP_ENV": "test"}, clear=True):
+            self.assertTrue(_allow_insecure_default_users())
+            self.assertFalse(_allow_insecure_default_personas())
             self.assertEqual(_bootstrap_admin_password(), "admin123")
 
     def test_production_env_blocks_fixed_demo_seed_by_default(self):
         with patch.dict("os.environ", {"APP_ENV": "production"}, clear=True):
             self.assertFalse(_allow_insecure_default_users())
+            self.assertFalse(_allow_insecure_default_personas())
             self.assertIsNone(_bootstrap_admin_password())
 
     def test_production_env_can_use_explicit_bootstrap_password(self):
@@ -39,6 +51,14 @@ class DatabaseBootstrapSecurityTest(unittest.TestCase):
             clear=True,
         ):
             self.assertTrue(_allow_insecure_default_users())
+
+    def test_non_local_persona_seed_requires_explicit_opt_in(self):
+        with patch.dict(
+            "os.environ",
+            {"APP_ENV": "staging", "ALLOW_INSECURE_DEFAULT_PERSONAS": "true"},
+            clear=True,
+        ):
+            self.assertTrue(_allow_insecure_default_personas())
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_user_list_endpoint.py
+++ b/backend/tests/test_user_list_endpoint.py
@@ -82,6 +82,16 @@ class UserListEndpointTest(unittest.TestCase):
         self.assertIsNotNone(row["last_activity_at"])
         self.assertFalse(row["is_overdue"])
 
+    def test_current_admin_activity_is_recorded_before_listing(self):
+        """管理頁自身的清單請求必須讓目前管理員列有最後活動時間。"""
+        self.assertIsNone(self.admin.last_activity_at)
+
+        row = self._find(self.client.get(LIST_URL).json()["items"], "admin")
+
+        self.assertIsNotNone(row["last_activity_at"])
+        self.db.refresh(self.admin)
+        self.assertIsNotNone(self.admin.last_activity_at)
+
     def test_overdue_flag_is_computed_by_backend(self):
         user = make_user(self.db, username="stale", role="Developer")
         user.last_activity_at = NOW - timedelta(days=200)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -35,6 +35,12 @@ POSTGRES_DB=cloud360
 # without it -- but a hand-copied file on the host has no such guard.
 JWT_SECRET=
 
+# Optional one-time bootstrap password for the `admin` Platform_Admin account.
+# Leave empty on an already-initialized environment. For a brand-new staging
+# database, set a strong temporary value through the GitHub secret
+# CLOUD360_BOOTSTRAP_ADMIN_PASSWORD, log in once, then rotate/clear it.
+CLOUD360_BOOTSTRAP_ADMIN_PASSWORD=
+
 # A1 design agent — Anthropic Agent SDK routed through OpenRouter.
 # Runtime still needs Claude Code CLI inside the backend image (see Dockerfile / DEPLOY.md §0).
 #

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -35,6 +35,7 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
+      CLOUD360_BOOTSTRAP_ADMIN_PASSWORD: ${CLOUD360_BOOTSTRAP_ADMIN_PASSWORD:-}
       # No fallback on purpose: this makes scripts/validate_env_contract.py
       # require render-env.sh and deploy/.env.example to keep writing it.
       LLM_PROVIDER: ${LLM_PROVIDER}

--- a/deploy/docker-compose.test.yml
+++ b/deploy/docker-compose.test.yml
@@ -2,9 +2,9 @@
 # minus the Cloudflare tunnel: the browser reaches nginx directly on
 # localhost:8090, and nginx reverse-proxies /api to the backend.
 #
-# The database is created fresh from schema_rbac.sql every run (no volume), so
-# the seeded admin / admin123 is expected and harmless — this stack never
-# touches production data.
+# The database is created fresh every run (no volume). The backend runs with
+# APP_ENV=test, so its local/test-only seed creates admin / admin123 for UI
+# regression; this stack never touches production data.
 #
 #   docker compose -f deploy/docker-compose.test.yml up -d --build
 

--- a/deploy/render-env.sh
+++ b/deploy/render-env.sh
@@ -16,6 +16,7 @@
 #
 #   POSTGRES_PASSWORD  required   database superuser password
 #   JWT_SECRET         required   signs every login token
+#   CLOUD360_BOOTSTRAP_ADMIN_PASSWORD optional one-time admin bootstrap password
 #   OPENROUTER_API_KEY optional   A1 design agent; empty disables generation
 #   N8N_WEBHOOK_URL    optional   dynamic architecture icons
 #   N8N_USER           optional   basic auth for the n8n webhook
@@ -64,6 +65,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 POSTGRES_DB=cloud360
 JWT_SECRET=${JWT_SECRET}
+CLOUD360_BOOTSTRAP_ADMIN_PASSWORD=${CLOUD360_BOOTSTRAP_ADMIN_PASSWORD:-}
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
 ANTHROPIC_BASE_URL=https://openrouter.ai/api

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -17,3 +17,7 @@ VITE_API_BASE_URL=http://localhost:8000
 
 # 可選：WebSocket 根 URL。未設定時由 VITE_API_BASE_URL 自動推導（http→ws、https→wss）
 # VITE_WS_BASE_URL=ws://localhost:8000
+
+# 可選：顯示 demo/persona 帳號快速填入。Vite dev mode 會自動顯示；
+# production build 預設不顯示，除非明確設為 true。
+# VITE_ENABLE_DEMO_QUICK_USERS=false

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "jspdf": "^4.2.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -21,7 +21,6 @@
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.5.0",
         "eslint": "^10.3.0",
@@ -49,13 +48,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -64,9 +63,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -74,21 +73,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -105,14 +104,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -122,14 +121,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -139,9 +138,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -149,29 +148,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -181,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -191,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -201,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -211,27 +210,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -250,33 +249,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -284,14 +283,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -595,9 +594,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -620,19 +619,27 @@
         "node": ">=18"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -647,9 +654,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +671,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -681,9 +688,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -698,9 +705,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -715,13 +722,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -732,13 +742,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,13 +762,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -766,13 +782,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -783,13 +802,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -800,13 +822,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -817,9 +842,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -833,29 +858,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -870,9 +876,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -1189,13 +1195,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1244,29 +1243,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -1655,16 +1631,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1749,6 +1725,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -1828,9 +1817,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -2754,9 +2743,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2890,9 +2879,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2950,9 +2939,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2970,7 +2959,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3037,35 +3026,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -3086,13 +3081,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3102,21 +3097,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/scheduler": {
@@ -3134,6 +3129,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3219,9 +3220,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3365,17 +3366,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3391,7 +3392,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -3440,6 +3441,279 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "jspdf": "^4.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -26,7 +26,6 @@
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.5.0",
     "eslint": "^10.3.0",

--- a/frontend/src/components/LastActivityCell.tsx
+++ b/frontend/src/components/LastActivityCell.tsx
@@ -16,20 +16,14 @@ interface LastActivityCellProps {
  *
  * **在地化策略**：換算為使用者的本地時區後再格式化。直接截斷 ISO 字串會讓顯示
  * 時間整體偏移一個時區位移量（AC-1.6 直接失敗）—— 後端一律回 UTC，顯示端負責
- * 在地化。`sv-SE` locale 的日期時間格式恰為 `YYYY-MM-DD HH:MM`，不需手動組字串。
+ * 在地化。輸出格式由本函式手動組成，避免不同瀏覽器／ICU locale 資料導致分隔符
+ * 或空白字元不一致。
  */
 function formatLocal(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return new Intl.DateTimeFormat('sv-SE', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-    .format(date)
-    .replace(',', '');
+  const pad2 = (value: number) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
 }
 
 /**

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -6,6 +6,18 @@ import type { StoryAction, User } from './auth-context';
 /** A1／A2／A4 視為同一「架構圖生成」能力，以 A1 為準 */
 const ARCH_STORIES = new Set(['A1', 'A2', 'A4']);
 const ARCH_CANONICAL = 'A1';
+const TOKEN_STORAGE_KEY = 'token';
+
+function getStoredToken(): string | null {
+  return sessionStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+function clearLegacyAuthStorage() {
+  localStorage.removeItem('token');
+  localStorage.removeItem('username');
+  localStorage.removeItem('role');
+  localStorage.removeItem('authorization_status');
+}
 
 async function fetchMe(tokenVal: string): Promise<User> {
   const res = await fetch(apiUrl('/api/auth/me'), {
@@ -29,31 +41,27 @@ async function fetchMe(tokenVal: string): Promise<User> {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
-  // 只有「真的要打 /me」時才處於 loading。用 lazy initial state 讀 localStorage，
+  // 只有「真的要打 /me」時才處於 loading。用 lazy initial state 讀 sessionStorage，
   // 沒有 token 的情況第一次 render 就是 false，不必在 effect body 內同步 setState
   // （react-hooks/set-state-in-effect），也省掉登入頁的載入畫面閃爍。
-  const [isLoading, setIsLoading] = useState(() => !!localStorage.getItem('token'));
+  const [isLoading, setIsLoading] = useState(() => !!getStoredToken());
 
   const applyUser = (u: User, tokenVal: string) => {
-    localStorage.setItem('token', tokenVal);
-    localStorage.setItem('username', u.username);
-    localStorage.setItem('role', u.role || '');
-    localStorage.setItem('authorization_status', u.authorization_status || 'approved');
+    clearLegacyAuthStorage();
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenVal);
     setToken(tokenVal);
     setUser(u);
   };
 
   const logout = useCallback(() => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('username');
-    localStorage.removeItem('role');
-    localStorage.removeItem('authorization_status');
+    clearLegacyAuthStorage();
+    sessionStorage.removeItem(TOKEN_STORAGE_KEY);
     setToken(null);
     setUser(null);
   }, []);
 
   const refreshMe = useCallback(async () => {
-    const activeToken = token || localStorage.getItem('token');
+    const activeToken = token || getStoredToken();
     if (!activeToken) return;
     const me = await fetchMe(activeToken);
     applyUser(me, activeToken);
@@ -61,8 +69,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // 初始化：有 token 則打 /me 取得最新 role + permissions
   useEffect(() => {
-    const savedToken = localStorage.getItem('token');
-    // isLoading 的初始值已由同一份 localStorage 判定，這裡直接返回即可。
+    clearLegacyAuthStorage();
+    const savedToken = getStoredToken();
+    // isLoading 的初始值已由同一份 sessionStorage 判定，這裡直接返回即可。
     if (!savedToken) return;
     fetchMe(savedToken)
       .then((me) => applyUser(me, savedToken))
@@ -71,9 +80,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, [logout]);
 
   const login = async (username: string, tokenVal: string, roleVal: string | null) => {
-    localStorage.setItem('token', tokenVal);
-    localStorage.setItem('username', username);
-    localStorage.setItem('role', roleVal || '');
+    clearLegacyAuthStorage();
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenVal);
     setToken(tokenVal);
     setUser({ username, role: roleVal, permissions: {}, authorization_status: 'approved' });
     try {
@@ -85,7 +93,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const checkAuthSession = async (): Promise<boolean> => {
-    const activeToken = token || localStorage.getItem('token');
+    const activeToken = token || getStoredToken();
     if (!activeToken) {
       logout();
       return false;

--- a/frontend/src/hooks/useCollaboration.ts
+++ b/frontend/src/hooks/useCollaboration.ts
@@ -3,10 +3,11 @@ import { wsUrl } from '../config/api';
 
 interface UseCollaborationProps {
   workspaceId: string;
+  token: string | null;
   onReceiveXml: (xml: string) => void;
 }
 
-export const useCollaboration = ({ workspaceId, onReceiveXml }: UseCollaborationProps) => {
+export const useCollaboration = ({ workspaceId, token, onReceiveXml }: UseCollaborationProps) => {
   const wsRef = useRef<WebSocket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   
@@ -17,9 +18,11 @@ export const useCollaboration = ({ workspaceId, onReceiveXml }: UseCollaboration
   }, [onReceiveXml]);
 
   useEffect(() => {
-    if (!workspaceId) return;
+    if (!workspaceId || !token) return;
 
-    const ws = new WebSocket(wsUrl(`/api/collab/ws/${workspaceId}`));
+    const url = new URL(wsUrl(`/api/collab/ws/${workspaceId}`));
+    url.searchParams.set('token', token);
+    const ws = new WebSocket(url.toString());
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -49,7 +52,7 @@ export const useCollaboration = ({ workspaceId, onReceiveXml }: UseCollaboration
     return () => {
       ws.close();
     };
-  }, [workspaceId]);
+  }, [workspaceId, token]);
 
   const broadcastXml = useCallback((xml: string) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -9,6 +9,9 @@ interface CatalogRole {
   features: string[];
 }
 
+const SHOW_DEMO_QUICK_USERS =
+  import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEMO_QUICK_USERS === 'true';
+
 export const LoginPage: React.FC = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -33,7 +36,7 @@ export const LoginPage: React.FC = () => {
         if (roles.length && !requestedRole) setRequestedRole(roles[0].role);
       })
       .catch(() => setCatalog([]));
-  }, [isRegisterMode]);
+  }, [isRegisterMode, requestedRole]);
 
   const handleToggleMode = () => {
     setIsRegisterMode(!isRegisterMode);
@@ -236,7 +239,7 @@ export const LoginPage: React.FC = () => {
             {isRegisterMode ? '已有帳號？立即登入系統' : '沒有帳號？立即註冊新帳號'}
           </button>
 
-          {!isRegisterMode && (
+          {!isRegisterMode && SHOW_DEMO_QUICK_USERS && (
             <>
               <button
                 onClick={() => setShowHelper(!showHelper)}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -72,6 +72,7 @@ export const WorkspacePage = () => {
 
   const { isConnected, broadcastXml } = useCollaboration({
     workspaceId: currentDiagramId ? currentDiagramId.toString() : '',
+    token,
     onReceiveXml: (newXml) => {
       if (newXml) {
         setXml(newXml);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   /** 可選 WebSocket 根；未設則由 API base 推導 */
   readonly VITE_WS_BASE_URL?: string;
+  /** 是否顯示 demo 帳號快速填入；部署預設關閉 */
+  readonly VITE_ENABLE_DEMO_QUICK_USERS?: string;
 }
 
 interface ImportMeta {

--- a/frontend/tests/e2e/regression.spec.ts
+++ b/frontend/tests/e2e/regression.spec.ts
@@ -5,8 +5,8 @@ import { test, expect, Page } from '@playwright/test';
 // OpenRouter, costs money, and is externally flaky). They exercise auth, RBAC
 // visibility, and navigation against the ephemeral stack's seeded data.
 //
-// Seeded by schema_rbac.sql on the fresh test DB: one user, admin / admin123,
-// role Platform_Admin. New registrations get role Developer.
+// Seeded by the ephemeral backend running with APP_ENV=test: one user,
+// admin / admin123, role Platform_Admin. New registrations start pending.
 
 const ADMIN = { username: 'admin', password: 'admin123' };
 
@@ -61,7 +61,7 @@ test.describe('身分驗證', () => {
    * @api GET /api/auth/me -> 200 | 取得目前登入者與其權限
    * @ui / | 登入頁：帳號／密碼輸入框、「登入系統」按鈕
    * @ui /workspace | 工作區：側邊導覽、「架構」按鈕、「登出系統」控制項
-   * @given seed 帳號 admin / admin123，角色 Platform_Admin
+   * @given test seed 帳號 admin / admin123，角色 Platform_Admin
    * @step 以 admin / admin123 送出登入 | 登入成功
    * @step 檢視當前路徑 | 導向 `/workspace`
    * @step 檢視工作區介面 | 出現「架構」按鈕
@@ -125,7 +125,7 @@ test.describe('角色權限存取控制 (RBAC)', () => {
    * @ui / | 登入頁：帳號／密碼輸入框、「登入系統」按鈕
    * @ui /workspace | 工作區：側邊導覽、「架構」按鈕、「登出系統」控制項
    * @ui /admin/authorization-requests | 授權申請審核頁：申請列表與「核准」按鈕
-   * @given seed 只有 admin；新註冊帳號預設角色為 Developer，且需管理員核准
+   * @given test seed 只有 admin；新註冊帳號申請 Developer，且需管理員核准
    * @step 以公開註冊建立一個唯一帳號（密碼 devpass123） | 註冊成功
    * @step 檢視當前路徑 | 導向 `/waiting-approval` 等待審核頁
    * @step 登出，改以 admin / admin123 登入 | 進入 `/workspace`

--- a/openapi.json
+++ b/openapi.json
@@ -520,6 +520,7 @@
               },
               "type": "object"
             },
+            "maxItems": 100,
             "title": "Messages",
             "type": "array"
           }
@@ -531,10 +532,14 @@
         "properties": {
           "title": {
             "default": "未命名架構圖",
+            "maxLength": 200,
+            "minLength": 1,
             "title": "Title",
             "type": "string"
           },
           "xml_data": {
+            "maxLength": 2097152,
+            "minLength": 1,
             "title": "Xml Data",
             "type": "string"
           }

--- a/schema_rbac.sql
+++ b/schema_rbac.sql
@@ -8,7 +8,7 @@
 --      另含 users.last_activity_at（最後活動時間欄位）
 --   E) A3：architecture_reviews（評核結果）+ wa_lenses（Offline Lens 現行標準）
 --   C) RBAC：role_permissions + 預設矩陣（308 列）
---   D) 預設管理員：admin / admin123（Platform_Admin）
+--   D) 不建立固定密碼管理員；bootstrap admin 由後端依環境變數建立
 --
 -- 執行（新環境可只跑這支）：
 --   psql "$DATABASE_URL" -f schema_rbac.sql
@@ -495,27 +495,6 @@ INSERT INTO role_permissions (role, story_id, can_view, can_edit, can_review) VA
   ('Platform_Admin', 'J3b', true, true, true),
   ('Platform_Owner', 'J3b', true, false, false)
 ;
-
--- ###########################################################################
--- D) Default admin account
---    username: admin
---    password: admin123   ※上線後請立即更換
--- ###########################################################################
-
-INSERT INTO users (username, password_hash, role, is_active)
-SELECT
-  'admin',
-  '$2b$12$3.9UUW/RwGhlhYd3qfBfcuFRALszLp6Wek7kDoVFSSgQNnuYn8pNG',
-  'Platform_Admin',
-  TRUE
-WHERE NOT EXISTS (
-  SELECT 1 FROM users WHERE username = 'admin'
-);
-
-UPDATE users
-SET role = 'Platform_Admin',
-    is_active = TRUE
-WHERE username = 'admin';
 
 COMMIT;
 


### PR DESCRIPTION
## Summary
- 強化 JWT secret 解析，避免 staging/production 使用公開 fallback key，並改用 timezone-aware expiry。
- 補上協作 WebSocket JWT 驗證、diagram ACL 與 payload 大小/XML 基本檢查。
- 移除 production 固定密碼 admin seed，改用可選 bootstrap admin secret，並同步部署文件與 env 範本。
- 將前端 auth token 改存 sessionStorage，隱藏 production demo quick-fill，清理 React Router 型別/依賴與 npm audit 漏洞。
- 更新 Pydantic v2 schema 設定與新增/調整安全回歸測試。

## Verification
- `cd backend && python3 -m unittest discover -s tests -v`
- `cd backend && python3 -m unittest tests.test_collab tests.test_auth tests.test_database_security -v`
- `python3 scripts/validate_env_contract.py && python3 scripts/validate_repo_contract.py`
- `cd frontend && npm ci --ignore-scripts`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm audit --audit-level=low`

## Issues
Refs #514
Refs #515
Refs #516
Refs #517
Refs #518
Refs #519
Refs #520
Refs #521
Refs #522
Refs #524
Refs #525

Note: #518 的硬編碼 audit path 在目前 `ut` 基底已經改為 logger 寫入，本 PR 保持該行為並納入同批追蹤。
