### PR TITLE
修正(api): /me 回應補上規格要求的 last_opened_diagram_id

### DIFF
--- a/backend/services/user_router.py
+++ b/backend/services/user_router.py
@@ -151,6 +151,11 @@ class MeResponse(BaseModel):
     authorization_status: str
     permissions: Dict[str, dict]
     pending_request: Optional[dict] = None
+    # 規格 §4.1.2 要求 /me 帶出此欄位。欄位本身早已存在（models.py 的 User
+    # 欄、database.py 的補欄、collab_router 的讀寫），只有這個回應模型漏掉，
+    # 所以 spec-sync 把它報成漂移（#468）。可為 null：使用者尚未開過任何圖，
+    # 或原圖已被刪除（外鍵為 ON DELETE SET NULL）。
+    last_opened_diagram_id: Optional[int] = None
 
 
 class UpdateRoleRequest(BaseModel):
@@ -427,6 +432,7 @@ def get_me(
             db, current_user.role, authorization_status=status_val
         ),
         "pending_request": pending,
+        "last_opened_diagram_id": current_user.last_opened_diagram_id,
     }
 
 

--- a/backend/tests/test_me_endpoint.py
+++ b/backend/tests/test_me_endpoint.py
@@ -1,0 +1,77 @@
+"""`GET /api/auth/me` 的回應形狀測試（起因 #468 的規格漂移報告）。
+
+漂移的形狀：`frontend-backend-specification.md` §4.1.2 要求回應帶
+`last_opened_diagram_id`，但 `MeResponse` 漏了它。欄位本身**早就存在**——
+`models.py` 有欄、`database.py` 有補欄、`collab_router.py` 讀寫它——只有這個
+回應模型沒宣告，於是 FastAPI 在序列化時把它丟掉。
+
+為何既有的閘門都攔不到：`tsc -b` 檢查的是「用法對型別檔」，不是「型別檔對規格」；
+e2e 沒有任何 case 讀 `/me` 的這個欄位；OpenAPI 漂移檢查比對的是「committed spec
+對 committed types」，兩者一起漏就一起過。只有直接斷言 HTTP 回應的欄位集合才擋得住。
+
+斷言**集合相等**而非「包含」：前者在漏欄位與多欄位兩個方向都會失敗。
+"""
+
+import unittest
+
+from starlette.testclient import TestClient
+
+from tests.helpers import close_session, make_session, make_user
+from database import get_db
+from main import app
+from services.auth import get_current_user
+from services.rbac import ensure_role_permissions_seeded
+
+ME_URL = "/api/auth/me"
+
+ME_FIELDS = {
+    "id",
+    "username",
+    "role",
+    "is_active",
+    "authorization_status",
+    "permissions",
+    "pending_request",
+    "last_opened_diagram_id",
+}
+
+
+class MeEndpointTest(unittest.TestCase):
+    def setUp(self):
+        self.db = make_session()
+        ensure_role_permissions_seeded(self.db, force=True)
+        self.admin = make_user(self.db, username="admin", role="Platform_Admin")
+        app.dependency_overrides[get_db] = lambda: self.db
+        app.dependency_overrides[get_current_user] = lambda: self.admin
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        close_session(self.db)
+
+    def test_response_field_set_matches_the_specification(self):
+        resp = self.client.get(ME_URL)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.json().keys()), ME_FIELDS)
+
+    def test_last_opened_diagram_id_is_null_when_never_opened(self):
+        """尚未開過任何圖時為 null —— 不是缺欄位，也不是 0。"""
+        resp = self.client.get(ME_URL)
+        self.assertIn("last_opened_diagram_id", resp.json())
+        self.assertIsNone(resp.json()["last_opened_diagram_id"])
+
+    def test_last_opened_diagram_id_carries_the_stored_value(self):
+        """有值時必須真的帶出來。
+
+        這是本次漂移的核心斷言：漏宣告欄位時，序列化會靜默丟棄它，回應看起來
+        「正常」但少一個鍵——上面的 null 測試單獨存在時擋不住這種情況，因為
+        「值是 None」與「欄位被丟掉」在寬鬆斷言下長得一樣。
+        """
+        self.admin.last_opened_diagram_id = 12
+        self.db.commit()
+        resp = self.client.get(ME_URL)
+        self.assertEqual(resp.json()["last_opened_diagram_id"], 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -782,6 +782,8 @@ export interface components {
             id: number;
             /** Is Active */
             is_active: boolean;
+            /** Last Opened Diagram Id */
+            last_opened_diagram_id?: number | null;
             /** Pending Request */
             pending_request?: {
                 [key: string]: unknown;

--- a/openapi.json
+++ b/openapi.json
@@ -255,6 +255,17 @@
             "title": "Is Active",
             "type": "boolean"
           },
+          "last_opened_diagram_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Opened Diagram Id"
+          },
           "pending_request": {
             "anyOf": [
               {


### PR DESCRIPTION
Closes #468

## 漂移確認

`frontend-backend-specification.md` §4.1.2 要求 `GET /api/auth/me` 回應帶 `last_opened_diagram_id`
（規格檔的 `:105`、`:175`、`:284` 三處），但 `MeResponse` 漏了宣告，FastAPI 序列化時直接丟掉。

**欄位本身早就存在**，只有回應模型沒宣告：

| 位置 | 狀態 |
|---|---|
| `backend/models.py:33` | `last_opened_diagram_id` 欄（外鍵 `ON DELETE SET NULL`） |
| `backend/database.py:184` | `ADD COLUMN IF NOT EXISTS` 補欄 |
| `backend/services/collab_router.py:352/406/411` | 讀寫，用於工作區還原 |
| `backend/services/user_router.py` `MeResponse` | **漏** |

## 一處要更正 #468 的內文

原報告寫「前端 `AuthContext.tsx` 依賴此欄位以判斷使用者進入工作區時應還原哪一張架構圖」。

**今天不成立。** `git grep last_opened_diagram_id -- frontend/src` 在 `main` 上**零命中**——前端沒有
任何一處引用它，工作區還原是在 `collab_router` 內以伺服器端完成的。

所以這個修正**不是解除前端阻塞**，理由是：規格是契約，而資料本來就在，補宣告的成本近乎零。若日後
決定改走「規格跟著實作走」，那要改的是規格而不是這裡——但那是設計決策，不該混在漂移修正裡。

## 為何六道既有閘門都攔不到

- `tsc -b` 檢查的是「用法對型別檔」，不是「型別檔對規格」
- e2e 沒有任何 case 讀 `/me` 的這個欄位
- OpenAPI 漂移檢查比對的是 **committed spec 對 committed types**——兩者一起漏就一起過

只有直接斷言 HTTP 回應欄位集合的測試擋得住，而 `/me` 先前**零測試覆蓋**。

## 回歸測試

`backend/tests/test_me_endpoint.py`，3 個，沿用 `test_user_list_endpoint.py` 建立的
`dependency_overrides` + `TestClient` 樣板（不需真實資料庫）。

斷言回應欄位的**集合相等**而非「包含」：後者只擋得住漏欄位，前者在漏欄位與多欄位兩個方向都會失敗。
其中一支刻意設值再讀回——因為「值是 `None`」與「欄位被丟掉」在寬鬆斷言下長得一模一樣，正是本次
漂移的形狀。

### 突變驗證

| 突變 | 結果 |
|---|---|
| 只移除 `MeResponse` 的欄位宣告，**保留回傳值** | 3 個測試中 **2 failures + 1 error** |
| 還原 | 247/247 全綠 |

### 驗證結果

- `cd backend && python3 -m unittest discover -s tests` → **247/247 OK**（244 → 247）
- `cd frontend && npm run check:types` → 「API 型別檔與規格檔一致」
- `python3 scripts/validate_repo_contract.py` → exit 0
- `openapi.json` 與 `frontend/src/types/api.d.ts` 已同步重新產生

## 未走 AI-DLC 流程

同 #523／#528／#529／#530：沒有開 intent、沒有跑 mandated 的 `tcms-test-cases` stage。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
